### PR TITLE
Fix build

### DIFF
--- a/build
+++ b/build
@@ -10,4 +10,5 @@ make -j8 libs
 
 echo "Building Go application..."
 cd -
+go get ./...
 go test -v


### PR DESCRIPTION
Since we can't `go get` this repo, we need to make sure that all its dependencies are available before trying to build it.

An alternative would be to vendor dependencies. What do you think @relistan?