### PR TITLE
Add support for scale factor

### DIFF
--- a/faster_raster.go
+++ b/faster_raster.go
@@ -101,7 +101,12 @@ func (r *Rasterizer) GeneratePage(pageNumber int, width int, scale float64) (ima
 		return nil, errors.New("Rasterizer has been cleaned up! Cannot re-use")
 	}
 
-	replyChan := make(chan *RasterReply)
+	// This channel must be buffered, or there is a race on the reply. If we
+	// don't start listening on the channel yet by the time the reply comes, then
+	// we will wait until the RasterTimeout and miss the returned response.
+	replyChan := make(chan *RasterReply, 1)
+
+	// Pass the request to the rendering function via the channel
 	r.RequestChan <- &RasterRequest{
 		PageNumber: pageNumber,
 		Width:      width,

--- a/faster_raster_test.go
+++ b/faster_raster_test.go
@@ -89,6 +89,51 @@ func Test_Processing(t *testing.T) {
 			raster.Stop()
 		})
 
+		Convey("returns an image with the correct width when specified", func() {
+			if testing.Short() {
+				return
+			}
+
+			raster.Run()
+			img, err := raster.GeneratePage(2, 1024, 0)
+
+			So(img, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+
+			So(img.Bounds().Max.X, ShouldEqual, 1024)
+			raster.Stop()
+		})
+
+		Convey("returns an image with the correct scale factor when specified", func() {
+			if testing.Short() {
+				return
+			}
+
+			raster.Run()
+			img, err := raster.GeneratePage(2, 0, 1.1)
+
+			So(img, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+
+			So(img.Bounds().Max.X, ShouldEqual, 655)
+			raster.Stop()
+		})
+
+		Convey("the width takes precedence over the scale factor", func() {
+			if testing.Short() {
+				return
+			}
+
+			raster.Run()
+			img, err := raster.GeneratePage(2, 1024, 1.1) // Specify BOTH
+
+			So(img, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+
+			So(img.Bounds().Max.X, ShouldEqual, 1024) // Should match -> width <-
+			raster.Stop()
+		})
+
 		Convey("handles more than one page image at a time", func() {
 			if testing.Short() {
 				return

--- a/faster_raster_test.go
+++ b/faster_raster_test.go
@@ -59,7 +59,7 @@ func Test_Processing(t *testing.T) {
 		Convey("returns an error when the rasterizer has not started", func() {
 			raster := NewRasterizer("fixtures/sample.pdf")
 			raster.hasRun = false
-			_, err := raster.GeneratePage(1, 1024)
+			_, err := raster.GeneratePage(1, 1024, 0)
 
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, "has not been started")
@@ -69,7 +69,7 @@ func Test_Processing(t *testing.T) {
 			err := raster.Run()
 			So(err, ShouldBeNil)
 
-			img, err := raster.GeneratePage(3, 1024)
+			img, err := raster.GeneratePage(3, 1024, 0)
 
 			So(img, ShouldBeNil)
 			So(err, ShouldEqual, ErrBadPage)
@@ -82,7 +82,7 @@ func Test_Processing(t *testing.T) {
 			}
 
 			raster.Run()
-			img, err := raster.GeneratePage(2, 1024)
+			img, err := raster.GeneratePage(2, 1024, 0)
 
 			So(img, ShouldNotBeNil)
 			So(err, ShouldBeNil)
@@ -109,7 +109,7 @@ func Test_Processing(t *testing.T) {
 			wg.Add(8)
 
 			go func() {
-				img1, err1 = raster.GeneratePage(1, 1024)
+				img1, err1 = raster.GeneratePage(1, 1024, 0)
 				if img1 != nil {
 					ok1 = true
 				}
@@ -117,7 +117,7 @@ func Test_Processing(t *testing.T) {
 			}()
 
 			go func() {
-				img2, err2 = raster.GeneratePage(1, 1024)
+				img2, err2 = raster.GeneratePage(1, 1024, 0)
 				if img2 != nil {
 					ok2 = true
 				}
@@ -125,7 +125,7 @@ func Test_Processing(t *testing.T) {
 			}()
 
 			go func() {
-				img3, err3 = raster.GeneratePage(2, 1024)
+				img3, err3 = raster.GeneratePage(2, 1024, 0)
 				if img3 != nil {
 					ok3 = true
 				}
@@ -133,7 +133,7 @@ func Test_Processing(t *testing.T) {
 			}()
 
 			go func() {
-				img4, err4 = raster.GeneratePage(2, 1024)
+				img4, err4 = raster.GeneratePage(2, 1024, 0)
 				if img4 != nil {
 					ok4 = true
 				}
@@ -143,7 +143,7 @@ func Test_Processing(t *testing.T) {
 			// Generate some more contention
 			for i := 0; i < 4; i++ {
 				go func() {
-					raster.GeneratePage(i%2+1, 1024)
+					raster.GeneratePage(i%2+1, 1024, 0)
 					wg.Done()
 				}()
 			}


### PR DESCRIPTION
This adds support for a scale factor that can be passed from the web handler down into the lazypdf library. It supports both a width and a scale factor, with the width taking precedence if both are specified.