### PR TITLE
Upgrade to mupdf-1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,8 @@ doing that (`image/jpeg`, `image/png`).
 Building
 --------
 
-Normally you can simply run `./build` and the shell script will do all the
-right things.  However, if you are building this on OSX, there is a bug in the
-version of MuPDF that we are using and it won't build properly. You'll need to
-apply the patch from [this
-bug](https://bugs.ghostscript.com/show_bug.cgi?id=697842) to make it compile
-properly on OSX. On Linux it should just work.
+You can simply run `./build` and the shell script will do all the right things
+on either Linux or OSX.
 
 Installing
 ----------
@@ -29,8 +25,8 @@ Anything that you then want to link against this library will need to use the
 correct Cgo configuration.  That should look like:
 
 ```go
-// #cgo CFLAGS: -I<relative path> -I<relative path>/mupdf-1.11-source/include -I<relative path>/mupdf-1.11-source/include/mupdf -I<relative path>/mupdf-1.11-source/thirdparty/openjpeg -I<relative path>/mupdf-1.11-source/thirdparty/jbig2dec -I<relative path>/mupdf-1.11-source/thirdparty/zlib -I<relative path>/mupdf-1.11-source/thirdparty/jpeg -I<relative path>/mupdf-1.11-source/thirdparty/freetype
-// #cgo LDFLAGS: -L<relative path>/mupdf-1.11-source/build/release -lmupdf -lmupdfthird -lm -ljbig2dec -lz -lfreetype -ljpeg -lcrypto -lpthread
+// #cgo CFLAGS: -I. -I./mupdf-1.12.0-source/include -I./mupdf-1.12.0-source/include/mupdf -I./mupdf-1.12.0-source/thirdparty/openjpeg -I./mupdf-1.12.0-source/thirdparty/jbig2dec -I./mupdf-1.12.0-source/thirdparty/zlib -I./mupdf-1.12.0-source/thirdparty/jpeg -I./mupdf-1.12.0-source/thirdparty/freetype -g
+// #cgo LDFLAGS: -L./mupdf-1.12.0-source/build/release -lmupdf -lmupdfthird -lm -ljbig2dec -lz -lfreetype -ljpeg -lcrypto -lpthread
 // #include <faster_raster.h>
 import "C"
 ```

--- a/build
+++ b/build
@@ -1,11 +1,11 @@
 #!/bin/bash -e
-if [[ ! -d mupdf-1.11-source ]]; then
+if [[ ! -d mupdf-1.12.0-source ]]; then
 	echo "Downloading muPDF..."
-	curl -L https://nitro-build-assets.s3.amazonaws.com/lazypdf/mupdf-1.11-source.tar.gz | tar -xzf -
+	curl -L https://nitro-build-assets.s3.amazonaws.com/lazypdf/mupdf-1.12.0-source.tar.gz | tar -xzf -
 fi
 
 echo "Building muPDF..."
-cd mupdf-1.11-source
+cd mupdf-1.12.0-source
 make -j8 libs
 
 echo "Building Go application..."

--- a/faster_raster.c
+++ b/faster_raster.c
@@ -1,5 +1,8 @@
 #include "faster_raster.h"
 
+#include <stdio.h>
+#include <string.h>
+
 // Format with:
 // indent -linux -br -brf
 

--- a/faster_raster.go
+++ b/faster_raster.go
@@ -11,8 +11,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// #cgo CFLAGS: -I. -I./mupdf-1.11-source/include -I./mupdf-1.11-source/include/mupdf -I./mupdf-1.11-source/thirdparty/openjpeg -I./mupdf-1.11-source/thirdparty/jbig2dec -I./mupdf-1.11-source/thirdparty/zlib -I./mupdf-1.11-source/thirdparty/jpeg -I./mupdf-1.11-source/thirdparty/freetype -g
-// #cgo LDFLAGS: -L./mupdf-1.11-source/build/release -lmupdf -lmupdfthird -lm -ljbig2dec -lz -lfreetype -ljpeg -lcrypto -lpthread
+// #cgo CFLAGS: -I. -I./mupdf-1.12.0-source/include -I./mupdf-1.12.0-source/include/mupdf -I./mupdf-1.12.0-source/thirdparty/openjpeg -I./mupdf-1.12.0-source/thirdparty/jbig2dec -I./mupdf-1.12.0-source/thirdparty/zlib -I./mupdf-1.12.0-source/thirdparty/jpeg -I./mupdf-1.12.0-source/thirdparty/freetype -g
+// #cgo LDFLAGS: -L./mupdf-1.12.0-source/build/release -lmupdf -lmupdfthird -lm -ljbig2dec -lz -lfreetype -ljpeg -lcrypto -lpthread
 // #include <faster_raster.h>
 import "C"
 
@@ -391,7 +391,7 @@ func (r *Rasterizer) processOne(req *RasterRequest) {
 	// back-to-back as RGBA starting at x,y,a 0,0,? .
 	// We'll free this C structure in a defer block later
 	pixmap := C.fz_new_pixmap_with_bbox_and_data(
-		r.Ctx, C.fz_device_rgb(r.Ctx), bbox, 1, (*C.uchar)(unsafe.Pointer(&bytes[0])),
+		r.Ctx, C.fz_device_rgb(r.Ctx), bbox, nil, 1, (*C.uchar)(unsafe.Pointer(&bytes[0])),
 	)
 	C.fz_clear_pixmap_with_value(r.Ctx, pixmap, C.int(0xff))
 

--- a/faster_raster.h
+++ b/faster_raster.h
@@ -5,6 +5,8 @@
 #include <pthread.h>
 #include <pdf/page.h>
 
+#include <stdlib.h>
+
 // indent -linux -br -brf
 
 // The number of mutexes we'll allocate


### PR DESCRIPTION
- The signature for `fz_new_pixmap_with_bbox_and_data` was changed to support "separations", whatever those are. From inspecting the implementation, it seems OK to pass `null` for this parameter.
- The OSX build was fixed. Yay!
- Need to manually include some stdlib headers since `fitz.h` doesn't bring them in any more.