### PR TITLE
Fall back to a default file type if not detected

### DIFF
--- a/faster_raster.c
+++ b/faster_raster.c
@@ -8,8 +8,8 @@
 
 // Have to wrap this macro so we can call from Cgo
 fz_context *cgo_fz_new_context(const fz_alloc_context * alloc,
-			       const fz_locks_context * locks,
-			       size_t max_store) {
+				   const fz_locks_context * locks,
+				   size_t max_store) {
 	return fz_new_context(alloc, locks, max_store);
 }
 
@@ -21,20 +21,58 @@ int cgo_ptr_cast(ptrdiff_t ptr) {
 
 // Wrap fz_open_document, which uses a try/catch exception handler
 // that we can't easily use from Go.
-fz_document *cgo_open_document(fz_context * ctx, const char *filename) {
+fz_document *cgo_open_document(fz_context *ctx, const char *filename, const char *default_ext) {
 	fz_document *doc = NULL;
+	int failed = 0;
 
 	fz_try(ctx) {
 		doc = fz_open_document(ctx, filename);
 	}
 	fz_catch(ctx) {
-		fprintf(stderr, "cannot open document: %s\n",
-			fz_caught_message(ctx));
-		return NULL;
+		fprintf(stderr, "Trying with default file extension for '%s'", filename);
+		failed = 1;
+	}
+
+	if(failed) {
+		fz_try(ctx) {
+			doc = open_document_with_extension(ctx, filename, default_ext);
+		}
+		fz_catch(ctx) {
+			fprintf(stderr, "cannot open document '%s': %s\n",
+				filename, fz_caught_message(ctx));
+			return NULL;
+		}
 	}
 
 	return doc;
 }
+
+fz_document *open_document_with_extension(fz_context *ctx, const char *filename, const char *default_ext) {
+	const fz_document_handler *handler;
+	fz_stream *file;
+	fz_document *doc = NULL;
+
+	handler = fz_recognize_document(ctx, default_ext);
+	if (!handler)
+		fz_throw(ctx, FZ_ERROR_GENERIC,
+			"cannot find doc handler for file extension: %s for document '%s'",
+			default_ext, filename);
+
+	if (handler->open)
+		return handler->open(ctx, filename);
+
+	file = fz_open_file(ctx, filename);
+
+	fz_try(ctx)
+		doc = handler->open_with_stream(ctx, file);
+	fz_always(ctx)
+		fz_drop_stream(ctx, file);
+	fz_catch(ctx)
+		fz_rethrow(ctx);
+
+	return doc;
+}
+
 
 // Wrap fz_drop_document to handle the exception trap when something is
 // wrong. We can't easily do this from Go.
@@ -79,7 +117,7 @@ fz_locks_context *new_locks() {
 	}
 
 	pthread_mutex_t *mutexes =
-	    malloc(sizeof(pthread_mutex_t) * FZ_LOCK_MAX);
+		malloc(sizeof(pthread_mutex_t) * FZ_LOCK_MAX);
 
 	if (mutexes == NULL) {
 		fprintf(stderr, "Unable to allocate mutexes!\n");
@@ -113,7 +151,7 @@ void free_locks(fz_locks_context * locks) {
 
 // Read a property from the PDF object by key name
 static pdf_obj *pdf_lookup_inherited_page_item(fz_context * ctx, pdf_obj * node,
-					       pdf_obj * key) {
+						   pdf_obj * key) {
 	pdf_obj *node2 = node;
 	pdf_obj *val;
 

--- a/faster_raster.h
+++ b/faster_raster.h
@@ -16,7 +16,8 @@ fz_context *cgo_fz_new_context(const fz_alloc_context * alloc,
 			       const fz_locks_context * locks,
 			       size_t max_store);
 int cgo_ptr_cast(ptrdiff_t ptr);
-fz_document *cgo_open_document(fz_context *ctx, const char *filename);
+fz_document *cgo_open_document(fz_context *ctx, const char *filename, const char *default_ext);
+fz_document *open_document_with_extension(fz_context *ctx, const char *filename, const char *default_ext);
 void cgo_drop_document(fz_context *ctx, fz_document *doc);
 void lock_mutex(void *locks, int lock_no);
 void unlock_mutex(void *locks, int lock_no);

--- a/faster_raster_test.go
+++ b/faster_raster_test.go
@@ -126,6 +126,33 @@ func Test_scalePage(t *testing.T) {
 	})
 }
 
+func Test_WithoutFileExtensions(t *testing.T) {
+	Convey("When the file has no file extension", t, func() {
+		Convey("but it is a PDF file, so it should work", func() {
+			raster := NewRasterizer("fixtures/sample_no_extension")
+			raster.Run()
+
+			_, err := raster.GeneratePage(1, 1024, 0)
+			So(err, ShouldBeNil)
+
+			raster.Stop()
+		})
+
+		Convey("but it is hot garbage, so it should fail", func() {
+			raster := NewRasterizer("fixtures/bad_data")
+			err := raster.Run()
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "Unable to open document")
+
+			_, err = raster.GeneratePage(1, 1024, 0)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "has been cleaned up")
+
+			raster.Stop()
+		})
+	})
+}
+
 func Test_Processing(t *testing.T) {
 	Convey("When processing the file", t, func() {
 		raster := NewRasterizer("fixtures/sample.pdf")


### PR DESCRIPTION
This fixes issues with files that have no file extension on MuPDF 1.12.0, which is not defaulting to PDF like previous versions did.