### PR TITLE
 Try to load system fonts when no matching font is available

### DIFF
--- a/faster_raster.c
+++ b/faster_raster.c
@@ -201,10 +201,11 @@ int get_rotation(fz_context * ctx, fz_page * page) {
 							 PDF_NAME_Rotate));
 }
 
-fz_font *load_system_font(fz_context * ctx, char *name, int bold, int italic) {
+fz_font *load_system_font(fz_context * ctx, char *path, int bold, int italic) {
 	fz_font *font;
 	fz_try(ctx)
-	    font = fz_new_font_from_file(ctx, NULL, name, 0, 0);
+	    // Note: We could load the font under a different name, if needed
+	    font = fz_new_font_from_file(ctx, NULL, path, 0, 0);
 	fz_catch(ctx)
 	    return NULL;
 

--- a/faster_raster.c
+++ b/faster_raster.c
@@ -12,8 +12,8 @@
 
 // Have to wrap this macro so we can call from Cgo
 fz_context *cgo_fz_new_context(const fz_alloc_context * alloc,
-				   const fz_locks_context * locks,
-				   size_t max_store) {
+			       const fz_locks_context * locks,
+			       size_t max_store) {
 	return fz_new_context(alloc, locks, max_store);
 }
 
@@ -25,7 +25,8 @@ int cgo_ptr_cast(ptrdiff_t ptr) {
 
 // Wrap fz_open_document, which uses a try/catch exception handler
 // that we can't easily use from Go.
-fz_document *cgo_open_document(fz_context *ctx, const char *filename, const char *default_ext) {
+fz_document *cgo_open_document(fz_context * ctx, const char *filename,
+			       const char *default_ext) {
 	fz_document *doc = NULL;
 	int failed = 0;
 
@@ -33,13 +34,16 @@ fz_document *cgo_open_document(fz_context *ctx, const char *filename, const char
 		doc = fz_open_document(ctx, filename);
 	}
 	fz_catch(ctx) {
-		fprintf(stderr, "Trying with default file extension for '%s'", filename);
+		fprintf(stderr, "Trying with default file extension for '%s'",
+			filename);
 		failed = 1;
 	}
 
-	if(failed) {
+	if (failed) {
 		fz_try(ctx) {
-			doc = open_document_with_extension(ctx, filename, default_ext);
+			doc =
+			    open_document_with_extension(ctx, filename,
+							 default_ext);
 		}
 		fz_catch(ctx) {
 			fprintf(stderr, "cannot open document '%s': %s\n",
@@ -51,7 +55,9 @@ fz_document *cgo_open_document(fz_context *ctx, const char *filename, const char
 	return doc;
 }
 
-fz_document *open_document_with_extension(fz_context *ctx, const char *filename, const char *default_ext) {
+fz_document *open_document_with_extension(fz_context * ctx,
+					  const char *filename,
+					  const char *default_ext) {
 	const fz_document_handler *handler;
 	fz_stream *file;
 	fz_document *doc = NULL;
@@ -59,8 +65,8 @@ fz_document *open_document_with_extension(fz_context *ctx, const char *filename,
 	handler = fz_recognize_document(ctx, default_ext);
 	if (!handler)
 		fz_throw(ctx, FZ_ERROR_GENERIC,
-			"cannot find doc handler for file extension: %s for document '%s'",
-			default_ext, filename);
+			 "cannot find doc handler for file extension: %s for document '%s'",
+			 default_ext, filename);
 
 	if (handler->open)
 		return handler->open(ctx, filename);
@@ -68,15 +74,14 @@ fz_document *open_document_with_extension(fz_context *ctx, const char *filename,
 	file = fz_open_file(ctx, filename);
 
 	fz_try(ctx)
-		doc = handler->open_with_stream(ctx, file);
+	    doc = handler->open_with_stream(ctx, file);
 	fz_always(ctx)
-		fz_drop_stream(ctx, file);
+	    fz_drop_stream(ctx, file);
 	fz_catch(ctx)
-		fz_rethrow(ctx);
+	    fz_rethrow(ctx);
 
 	return doc;
 }
-
 
 // Wrap fz_drop_document to handle the exception trap when something is
 // wrong. We can't easily do this from Go.
@@ -121,7 +126,7 @@ fz_locks_context *new_locks() {
 	}
 
 	pthread_mutex_t *mutexes =
-		malloc(sizeof(pthread_mutex_t) * FZ_LOCK_MAX);
+	    malloc(sizeof(pthread_mutex_t) * FZ_LOCK_MAX);
 
 	if (mutexes == NULL) {
 		fprintf(stderr, "Unable to allocate mutexes!\n");
@@ -155,7 +160,7 @@ void free_locks(fz_locks_context * locks) {
 
 // Read a property from the PDF object by key name
 static pdf_obj *pdf_lookup_inherited_page_item(fz_context * ctx, pdf_obj * node,
-						   pdf_obj * key) {
+					       pdf_obj * key) {
 	pdf_obj *node2 = node;
 	pdf_obj *val;
 
@@ -213,8 +218,8 @@ fz_font *load_system_font(fz_context * ctx, char *name, int bold, int italic) {
 struct fz_font_s *load_system_font_proxy(fz_context * ctx, const char *name,
 					 int bold, int italic,
 					 int /* unused */ needs_exact_metrics) {
-	// TODO: Investigate what is the intent of needs_exact_metrics
-	// SumatraPDF Reader makes use of it. See comment in LoadSystemFont
+	// TODO: Investigate what is the intent of needs_exact_metrics.
+	// SumatraPDF Reader makes use of it. See comment in LoadSystemFont.
 	return LoadSystemFont(ctx, (char *)name, bold, italic);
 }
 

--- a/faster_raster.go
+++ b/faster_raster.go
@@ -41,10 +41,13 @@ var (
 	defaultExtension = C.CString(".pdf")
 
 	// Available system font names mapped to their file paths.
-	systemFontPaths map[string]string
+	systemFontPaths FontPaths
 	// LRU cache of fz_font objects corresponding to loaded system fonts.
 	fontCache *lru.Cache
 )
+
+// FontPaths is a map of font names and font file paths
+type FontPaths map[string]string
 
 // IsBadPage validates that the type of error was an ErrBadPage.
 func IsBadPage(err error) bool {
@@ -68,7 +71,7 @@ type RasterReply struct {
 	Error error
 }
 
-func SetSystemFonts(fontPaths map[string]string) {
+func SetSystemFonts(fontPaths FontPaths) {
 	systemFontPaths = fontPaths
 }
 

--- a/faster_raster.go
+++ b/faster_raster.go
@@ -98,11 +98,13 @@ func LoadSystemFont(ctx *C.struct_fz_context_s, cgoName *C.char, cgoBold, cgoIta
 		name = name[:len(name)-2]
 	}
 
-	if bold != 0 && italic != 0 {
-		name = fmt.Sprintf("%sBoldItalic", name)
-	} else if bold != 0 {
+	// Remove spaces
+	name = strings.Replace(name, " ", "", -1)
+
+	if bold != 0 {
 		name = fmt.Sprintf("%sBold", name)
-	} else if italic != 0 {
+	}
+	if italic != 0 {
 		name = fmt.Sprintf("%sItalic", name)
 	}
 

--- a/faster_raster.h
+++ b/faster_raster.h
@@ -1,9 +1,4 @@
 #include <fitz.h>
-#include <pdf/name-table.h>
-#include <pdf/object.h>
-#include <pdf/document.h>
-#include <pthread.h>
-#include <pdf/page.h>
 
 #include <stdlib.h>
 
@@ -24,3 +19,5 @@ void unlock_mutex(void *locks, int lock_no);
 fz_locks_context *new_locks();
 void free_locks(fz_locks_context * locks);
 int get_rotation(fz_context *ctx, fz_page *page);
+void register_load_system_font_callback(fz_context *ctx);
+fz_font *load_system_font(fz_context *ctx, char *name, int bold, int italic);


### PR DESCRIPTION
This should do the trick for now, I hope.

-  [ ] TODO: Maybe we need to pass in a custom name for certain fonts via the [name parameter](https://github.com/ArtifexSoftware/mupdf/blob/e552f404a7c521bbfe32fb1be1d44ad0ba92c014/include/mupdf/fitz/font.h#L433) of `fz_new_font_from_file`. For example, if we want to map a font to a different font.

PS: I also ran `indent` on faster_raster.c.