### PR TITLE
Need to pass a reference to the original pointer to be able to set it to NULL in C

### DIFF
--- a/faster_raster.c
+++ b/faster_raster.c
@@ -144,10 +144,10 @@ fz_locks_context *new_locks() {
 
 // Free the lock structure in C since we allocated the memory
 // here.
-void free_locks(fz_locks_context * locks) {
-	free(locks->user);
-	free(locks);
-	locks = NULL;
+void free_locks(fz_locks_context ** locks) {
+	free((*locks)->user);
+	free(*locks);
+	*locks = NULL;
 }
 
 // Read a property from the PDF object by key name

--- a/faster_raster.go
+++ b/faster_raster.go
@@ -211,7 +211,7 @@ func (r *Rasterizer) finalCleanUp() {
 		r.RequestChan = nil
 	}
 
-	C.free_locks(r.locks)
+	C.free_locks(&r.locks)
 
 	// Used by tests that need to know when this is fully complete.
 	// stopCompleted is not normally allocated so it will be nil.

--- a/faster_raster.h
+++ b/faster_raster.h
@@ -22,5 +22,5 @@ void cgo_drop_document(fz_context *ctx, fz_document *doc);
 void lock_mutex(void *locks, int lock_no);
 void unlock_mutex(void *locks, int lock_no);
 fz_locks_context *new_locks();
-void free_locks(fz_locks_context * locks);
+void free_locks(fz_locks_context ** locks);
 int get_rotation(fz_context *ctx, fz_page *page);


### PR DESCRIPTION
This is caused by the changes from #12. Setting a CGo pointer to NULL from C works as expected, but we need to pass a reference to it into `free_locks`.