### PR TITLE
Release resources on stop only after all the raster operations have completed

### DIFF
--- a/faster_raster.go
+++ b/faster_raster.go
@@ -33,8 +33,6 @@ var (
 	ErrBadPage = errors.New("invalid page number")
 	// We tried to rasterize the page, but we gave up waiting.
 	ErrRasterTimeout = errors.New("rasterizer timed out!")
-	// MuPDF failed to clone the context
-	ErrCloneCtx = errors.New("failed to clone context")
 
 	defaultExtension = C.CString(".pdf")
 )
@@ -342,7 +340,7 @@ func (r *Rasterizer) processOne(req *RasterRequest) {
 	// Create a clone of r.Ctx for objects that are allocated for rendering the current page
 	ctx := C.fz_clone_context(r.Ctx)
 	if ctx == nil {
-		req.ReplyChan <- &RasterReply{Error: ErrCloneCtx}
+		req.ReplyChan <- &RasterReply{Error: errors.New("failed to clone context")}
 	}
 
 	// Load the page and allocate C structure, freed later

--- a/faster_raster.go
+++ b/faster_raster.go
@@ -327,7 +327,7 @@ func (r *Rasterizer) processOne(req *RasterRequest) {
 		// Try to reply but don't block if something happened to the reply channel
 		select {
 		case req.ReplyChan <- &RasterReply{Error: ErrBadPage}:
-			// Nothing
+			log.Warnf("Requested page %d is greater than the document page count %d", req.PageNumber, r.docPageCount)
 		default:
 			log.Warnf(
 				"Failed to reply for %s page %d, with bad page error",

--- a/faster_raster_test.go
+++ b/faster_raster_test.go
@@ -183,8 +183,8 @@ func Test_Processing(t *testing.T) {
 			raster.Run()
 			img, err := raster.GeneratePage(2, 1024, 0)
 
-			So(img, ShouldNotBeNil)
 			So(err, ShouldBeNil)
+			So(img, ShouldNotBeNil)
 			raster.Stop()
 		})
 
@@ -196,8 +196,8 @@ func Test_Processing(t *testing.T) {
 			raster.Run()
 			img, err := raster.GeneratePage(2, 1024, 0)
 
-			So(img, ShouldNotBeNil)
 			So(err, ShouldBeNil)
+			So(img, ShouldNotBeNil)
 
 			So(img.Bounds().Max.X, ShouldEqual, 1024)
 			raster.Stop()
@@ -211,8 +211,8 @@ func Test_Processing(t *testing.T) {
 			raster.Run()
 			img, err := raster.GeneratePage(2, 0, 1.1)
 
-			So(img, ShouldNotBeNil)
 			So(err, ShouldBeNil)
+			So(img, ShouldNotBeNil)
 
 			So(img.Bounds().Max.X, ShouldEqual, 655)
 			raster.Stop()
@@ -226,8 +226,8 @@ func Test_Processing(t *testing.T) {
 			raster.Run()
 			img, err := raster.GeneratePage(2, 1024, 1.1) // Specify BOTH
 
-			So(img, ShouldNotBeNil)
 			So(err, ShouldBeNil)
+			So(img, ShouldNotBeNil)
 
 			So(img.Bounds().Max.X, ShouldEqual, 1024) // Should match -> width <-
 			raster.Stop()
@@ -242,8 +242,8 @@ func Test_Processing(t *testing.T) {
 			raster.Run()
 			img, err := raster.GeneratePage(2, 0, 0) // Specify NEITHER scale nor width
 
-			So(img, ShouldNotBeNil)
 			So(err, ShouldBeNil)
+			So(img, ShouldNotBeNil)
 
 			So(img.Bounds().Max.X, ShouldEqual, 893) // Portrait file, should be 1.5 scaling
 			raster.Stop()

--- a/faster_raster_test.go
+++ b/faster_raster_test.go
@@ -329,10 +329,6 @@ func Test_Processing(t *testing.T) {
 		})
 
 		Convey("counts the number of pages in the document when raster starts", func() {
-			if testing.Short() {
-				return
-			}
-
 			raster.Run()
 
 			So(raster.docPageCount, ShouldEqual, 2)

--- a/faster_raster_test.go
+++ b/faster_raster_test.go
@@ -299,6 +299,18 @@ func Test_Processing(t *testing.T) {
 			raster.Stop()
 		})
 
+		Convey("counts the number of pages in the document when raster starts", func() {
+			if testing.Short() {
+				return
+			}
+
+			raster.Run()
+
+			So(raster.docPageCount, ShouldEqual, 2)
+
+			raster.Stop()
+		})
+
 		Convey("handles more than one page image at a time", func() {
 			if testing.Short() {
 				return


### PR DESCRIPTION
This is my attempt at tackling the failure that started happening after https://github.com/Nitro/lazypdf/pull/13 and it should be a safer way of freeing resources by forcing `finalCleanUp` to run only after all the `backgroundRender` operations have completed.

One potential reason to use the cloned ctx as early as possible is to avoid having an error in one pthread being picked up in another one. This is based on my interpretation of [reading the docs](https://mupdf.com/docs/coding-overview.html) on `fz_clone_context`.

This build has succeeded: https://travis-ci.org/Nitro/lazypdf/builds/380098660 (looks like Travis is really slow).

TODO:
- [x] Rebase after #16 gets merged