### PR TITLE
 Update cgo linker flags to link only from lib mupdfthird

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 sudo: required
 
 before_install:
-  - sudo apt-get install -y zlib1g libpng12-0 ca-certificates
+  - sudo apt-get install -y ca-certificates
   - ./build
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 sudo: required
 
 before_install:
-  - sudo apt-get install -y libjpeg62 zlib1g libjbig2dec0 libjbig2dec0-dev libfreetype6 libpng12-0 ca-certificates
+  - sudo apt-get install -y zlib1g libpng12-0 ca-certificates
   - ./build
 
 script:

--- a/faster_raster.go
+++ b/faster_raster.go
@@ -13,7 +13,7 @@ import (
 )
 
 // #cgo CFLAGS: -I. -I./mupdf/include -I./mupdf/include/mupdf -I./mupdf/thirdparty/openjpeg -I./mupdf/thirdparty/jbig2dec -I./mupdf/thirdparty/zlib -I./mupdf/thirdparty/jpeg -I./mupdf/thirdparty/freetype
-// #cgo LDFLAGS: -L./mupdf/build/release -lmupdf -lmupdfthird -lm -ljbig2dec -lz -lfreetype -ljpeg -lcrypto -lpthread
+// #cgo LDFLAGS: -L./mupdf/build/release -lmupdf -lmupdfthird -lm  -lz -lcrypto -lpthread
 // #include <faster_raster.h>
 import "C"
 

--- a/faster_raster.go
+++ b/faster_raster.go
@@ -13,7 +13,7 @@ import (
 )
 
 // #cgo CFLAGS: -I. -I./mupdf/include -I./mupdf/include/mupdf -I./mupdf/thirdparty/openjpeg -I./mupdf/thirdparty/jbig2dec -I./mupdf/thirdparty/zlib -I./mupdf/thirdparty/jpeg -I./mupdf/thirdparty/freetype
-// #cgo LDFLAGS: -L./mupdf/build/release -lmupdf -lmupdfthird -lm  -lz -lcrypto -lpthread
+// #cgo LDFLAGS: -L./mupdf/build/release -lmupdf -lmupdfthird -lm -lcrypto -lpthread
 // #include <faster_raster.h>
 import "C"
 


### PR DESCRIPTION
`mupdf` project vendor all the thirdparty libraries and generate a [unix single archive](https://en.wikipedia.org/wiki/Ar_(Unix)) format into `mupdf/build/release/libmupdfthird.a`.

- **On Linux**: We can confirm symbols from the objects files are present in the resulting archive and we can look up them using [nm](https://en.wikipedia.org/wiki/Nm_(Unix)). `ft_alloc` came with `freetype` and `jbig2_alloc` came with `jbig2dec`:

```
nm  mupdf/build/release/libmupdfthird.a |grep '\(ft\|jbig2\)_alloc'
```

- **On OSX**: We can confirm and look up object files which contains symbols using [otool](https://www.unix.com/man-page/osx/1/otool/):

```
otool -L ./mupdf/build/release/libmupdfthird.a |grep '\(jbig2\|ftbase\).o'
```

I think we don't need to rely on the external libraries `jbig2dec`, `freetype`, `jpeg`. For that reason, I remove them for the **CGO_LDFLAGS**.

Also, I remove them from the [travis config](.travis.yml).

Build and `go test` should be successful on OSX and Linux.