### PR TITLE
Fix invalid page crashes

### DIFF
--- a/faster_raster.h
+++ b/faster_raster.h
@@ -24,3 +24,4 @@ void unlock_mutex(void *locks, int lock_no);
 fz_locks_context *new_locks();
 void free_locks(fz_locks_context ** locks);
 int get_rotation(fz_context *ctx, fz_page *page);
+fz_page *load_page(fz_context *ctx, fz_document *doc, int number);

--- a/faster_raster_test.go
+++ b/faster_raster_test.go
@@ -56,8 +56,16 @@ func Test_getRotation(t *testing.T) {
 		raster := NewRasterizer("fixtures/rotated-sample.pdf")
 		raster.Run()
 
-		So(raster.getRotation(1), ShouldEqual, 180)
-		So(raster.getRotation(2), ShouldEqual, 0)
+		rot, err := raster.getRotation(0)
+		So(err, ShouldEqual, ErrBadPage)
+
+		rot, err = raster.getRotation(1)
+		So(err, ShouldBeNil)
+		So(rot, ShouldEqual, 180)
+
+		rot, err = raster.getRotation(2)
+		So(err, ShouldBeNil)
+		So(rot, ShouldEqual, 0)
 
 		raster.Stop()
 	})
@@ -172,6 +180,11 @@ func Test_Processing(t *testing.T) {
 
 			So(img, ShouldBeNil)
 			So(err, ShouldEqual, ErrBadPage)
+
+			img, err = raster.GeneratePage(0, 1024, 0)
+			So(img, ShouldBeNil)
+			So(err, ShouldEqual, ErrBadPage)
+
 			raster.Stop()
 		})
 


### PR DESCRIPTION
For some reason, lazypdf did not reject requests with page < 1, which make it crash. I restricted this explicitly in `processOne`.

Also, although the docs don't mention this, the [pdf implementation](https://github.com/ArtifexSoftware/mupdf/blob/ce3e98c07e29dab2743e792e478395ed30d27dc1/source/pdf/pdf-page.c#L1058) of `fz_load_page` can throw in several situations, besides invalid page numbers, so I decided to create a `load_page` wrapper for `fz_load_page` which catches any error coming out of it instead of letting the process die by bubbling up the mupdf exception.