### PR TITLE
Raster to SVG reloaded

### DIFF
--- a/faster_raster_test.go
+++ b/faster_raster_test.go
@@ -214,9 +214,9 @@ func Test_Processing(t *testing.T) {
 			svg, err := raster.GeneratePageSVG(2, 1024, 0)
 
 			So(err, ShouldBeNil)
-			So(svg, ShouldStartWith, `<?xml version="1.0" encoding="UTF-8" standalone="no"?>`)
-			So(svg, ShouldContainSubstring, "</clipPath>")
-			So(svg, ShouldEndWith, "</svg>\n")
+			So(string(svg), ShouldStartWith, `<?xml version="1.0" encoding="UTF-8" standalone="no"?>`)
+			So(string(svg), ShouldContainSubstring, "</clipPath>")
+			So(string(svg), ShouldEndWith, "</svg>\n")
 			raster.Stop()
 		})
 
@@ -434,7 +434,7 @@ func Test_Processing(t *testing.T) {
 
 			var err1, err2 error
 			var img image.Image
-			var svg string
+			var svg []byte
 
 			var wg sync.WaitGroup
 			wg.Add(2)
@@ -456,7 +456,7 @@ func Test_Processing(t *testing.T) {
 
 			// Checking img using ShouldNotBeNil is really slow...
 			So(img != nil, ShouldBeTrue)
-			So(svg, ShouldNotBeBlank)
+			So(svg, ShouldNotBeNil)
 
 			raster.Stop()
 		})

--- a/faster_raster_test.go
+++ b/faster_raster_test.go
@@ -78,7 +78,7 @@ func Test_scalePage(t *testing.T) {
 				raster := NewRasterizer("fixtures/landscape-sample.pdf")
 				raster.Run()
 
-				img, err := raster.GeneratePage(1, 0, 0)
+				img, err := raster.GeneratePageImage(1, 0, 0)
 
 				So(err, ShouldBeNil)
 				So(img.Bounds().Max.X, ShouldEqual, 842)
@@ -89,7 +89,7 @@ func Test_scalePage(t *testing.T) {
 			Convey("as PortraitScale when pages were rotated", func() {
 				raster := NewRasterizer("fixtures/rotated-sample.pdf")
 				raster.Run()
-				img, err := raster.GeneratePage(1, 0, 0)
+				img, err := raster.GeneratePageImage(1, 0, 0)
 
 				So(err, ShouldBeNil)
 				So(img.Bounds().Max.X, ShouldEqual, 842)
@@ -101,7 +101,7 @@ func Test_scalePage(t *testing.T) {
 		Convey("handles portrait pages as PortraitScale", func() {
 			raster := NewRasterizer("fixtures/sample.pdf")
 			raster.Run()
-			img, err := raster.GeneratePage(1, 0, 0)
+			img, err := raster.GeneratePageImage(1, 0, 0)
 
 			So(err, ShouldBeNil)
 			So(img.Bounds().Max.X, ShouldEqual, 893)
@@ -112,7 +112,7 @@ func Test_scalePage(t *testing.T) {
 		Convey("uses LandscapeScale if any page is landscape", func() {
 			raster := NewRasterizer("fixtures/mixed-sample.pdf")
 			raster.Run()
-			img, err := raster.GeneratePage(2, 0, 0)
+			img, err := raster.GeneratePageImage(2, 0, 0)
 
 			So(err, ShouldBeNil)
 			So(img.Bounds().Max.X, ShouldEqual, 612)
@@ -123,7 +123,7 @@ func Test_scalePage(t *testing.T) {
 		Convey("uses specified scale if there is one", func() {
 			raster := NewRasterizer("fixtures/mixed-sample.pdf")
 			raster.Run()
-			img, err := raster.GeneratePage(2, 0, 0.5)
+			img, err := raster.GeneratePageImage(2, 0, 0.5)
 
 			So(err, ShouldBeNil)
 			So(img.Bounds().Max.X, ShouldEqual, 306)
@@ -139,7 +139,7 @@ func Test_WithoutFileExtensions(t *testing.T) {
 			raster := NewRasterizer("fixtures/sample_no_extension")
 			raster.Run()
 
-			_, err := raster.GeneratePage(1, 1024, 0)
+			_, err := raster.GeneratePageImage(1, 1024, 0)
 			So(err, ShouldBeNil)
 
 			raster.Stop()
@@ -151,7 +151,7 @@ func Test_WithoutFileExtensions(t *testing.T) {
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, "Unable to open document")
 
-			_, err = raster.GeneratePage(1, 1024, 0)
+			_, err = raster.GeneratePageImage(1, 1024, 0)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, "has been cleaned up")
 
@@ -165,7 +165,7 @@ func Test_Processing(t *testing.T) {
 		raster := NewRasterizer("fixtures/sample.pdf")
 
 		Convey("returns an error when the rasterizer has not started", func() {
-			_, err := raster.GeneratePage(1, 1024, 0)
+			_, err := raster.GeneratePageImage(1, 1024, 0)
 
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, "has not been started")
@@ -176,12 +176,12 @@ func Test_Processing(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(raster.docPageCount, ShouldEqual, 2)
 
-			img, err := raster.GeneratePage(3, 1024, 0)
+			img, err := raster.GeneratePageImage(3, 1024, 0)
 
 			So(img, ShouldBeNil)
 			So(err, ShouldEqual, ErrBadPage)
 
-			img, err = raster.GeneratePage(0, 1024, 0)
+			img, err = raster.GeneratePageImage(0, 1024, 0)
 			So(img, ShouldBeNil)
 			So(err, ShouldEqual, ErrBadPage)
 
@@ -196,7 +196,7 @@ func Test_Processing(t *testing.T) {
 			err := raster.Run()
 			So(err, ShouldBeNil)
 
-			img, err := raster.GeneratePage(2, 1024, 0)
+			img, err := raster.GeneratePageImage(2, 1024, 0)
 
 			So(err, ShouldBeNil)
 			So(img, ShouldNotBeNil)
@@ -213,7 +213,7 @@ func Test_Processing(t *testing.T) {
 			go raster.Stop()
 			<-raster.stopCompleted
 
-			_, err := raster.GeneratePage(1, 1024, 0)
+			_, err := raster.GeneratePageImage(1, 1024, 0)
 
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, "has been stopped")
@@ -240,7 +240,7 @@ func Test_Processing(t *testing.T) {
 			// We have to give the background goroutine a little time to start :(
 			time.Sleep(5 * time.Millisecond)
 
-			replyChan := make(chan *RasterReply, 1)
+			replyChan := make(chan ReplyWrapper, 1)
 
 			// Pass the request to the rendering function via the channel
 			raster.RequestChan <- &RasterRequest{
@@ -256,7 +256,7 @@ func Test_Processing(t *testing.T) {
 
 			// Wait for a reply or a timeout, whichever occurs first
 			timeoutOccured := false
-			var response *RasterReply
+			var response ReplyWrapper
 			select {
 			case response = <-replyChan:
 				close(replyChan)
@@ -265,8 +265,9 @@ func Test_Processing(t *testing.T) {
 				timeoutOccured = true
 			}
 			So(timeoutOccured, ShouldBeFalse)
-			So(response.Error, ShouldBeNil)
-			So(response.Image, ShouldNotBeNil)
+			So(response, ShouldNotBeNil)
+			So(response.Error(), ShouldBeNil)
+			So(response.(*RasterImageReply).Image, ShouldNotBeNil)
 		})
 
 		Convey("returns an image with the correct width when specified", func() {
@@ -275,7 +276,7 @@ func Test_Processing(t *testing.T) {
 			}
 
 			raster.Run()
-			img, err := raster.GeneratePage(2, 1024, 0)
+			img, err := raster.GeneratePageImage(2, 1024, 0)
 
 			So(err, ShouldBeNil)
 			So(img, ShouldNotBeNil)
@@ -290,7 +291,7 @@ func Test_Processing(t *testing.T) {
 			}
 
 			raster.Run()
-			img, err := raster.GeneratePage(2, 0, 1.1)
+			img, err := raster.GeneratePageImage(2, 0, 1.1)
 
 			So(err, ShouldBeNil)
 			So(img, ShouldNotBeNil)
@@ -305,7 +306,7 @@ func Test_Processing(t *testing.T) {
 			}
 
 			raster.Run()
-			img, err := raster.GeneratePage(2, 1024, 1.1) // Specify BOTH
+			img, err := raster.GeneratePageImage(2, 1024, 1.1) // Specify BOTH
 
 			So(err, ShouldBeNil)
 			So(img, ShouldNotBeNil)
@@ -321,7 +322,7 @@ func Test_Processing(t *testing.T) {
 
 			// PORTRAIT
 			raster.Run()
-			img, err := raster.GeneratePage(2, 0, 0) // Specify NEITHER scale nor width
+			img, err := raster.GeneratePageImage(2, 0, 0) // Specify NEITHER scale nor width
 
 			So(err, ShouldBeNil)
 			So(img, ShouldNotBeNil)
@@ -333,7 +334,7 @@ func Test_Processing(t *testing.T) {
 			raster = NewRasterizer("fixtures/landscape-sample.pdf")
 			raster.Run()
 
-			img, err = raster.GeneratePage(1, 0, 0) // Specify NEITHER scale nor width
+			img, err = raster.GeneratePageImage(1, 0, 0) // Specify NEITHER scale nor width
 			So(img, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 
@@ -369,7 +370,7 @@ func Test_Processing(t *testing.T) {
 			wg.Add(8)
 
 			go func() {
-				img1, err1 = raster.GeneratePage(1, 1024, 0)
+				img1, err1 = raster.GeneratePageImage(1, 1024, 0)
 				if img1 != nil {
 					ok1 = true
 				}
@@ -377,7 +378,7 @@ func Test_Processing(t *testing.T) {
 			}()
 
 			go func() {
-				img2, err2 = raster.GeneratePage(1, 1024, 0)
+				img2, err2 = raster.GeneratePageImage(1, 1024, 0)
 				if img2 != nil {
 					ok2 = true
 				}
@@ -385,7 +386,7 @@ func Test_Processing(t *testing.T) {
 			}()
 
 			go func() {
-				img3, err3 = raster.GeneratePage(2, 1024, 0)
+				img3, err3 = raster.GeneratePageImage(2, 1024, 0)
 				if img3 != nil {
 					ok3 = true
 				}
@@ -393,7 +394,7 @@ func Test_Processing(t *testing.T) {
 			}()
 
 			go func() {
-				img4, err4 = raster.GeneratePage(2, 1024, 0)
+				img4, err4 = raster.GeneratePageImage(2, 1024, 0)
 				if img4 != nil {
 					ok4 = true
 				}
@@ -404,7 +405,7 @@ func Test_Processing(t *testing.T) {
 			for i := 0; i < 4; i++ {
 				page := i%2 + 1
 				go func() {
-					raster.GeneratePage(page, 1024, 0)
+					raster.GeneratePageImage(page, 1024, 0)
 					wg.Done()
 				}()
 			}

--- a/faster_raster_test.go
+++ b/faster_raster_test.go
@@ -360,44 +360,26 @@ func Test_Processing(t *testing.T) {
 			var err1, err2, err3, err4 error
 			var img1, img2, img3, img4 image.Image
 
-			// These are used in the goroutines instead of checking imgX individually
-			// as ShouldNotBeNil, because something about the copying in the test
-			// framework seems to make that take about 1 second each! Doing it this
-			// way shaves about 3 seconds off the tests.
-			var ok1, ok2, ok3, ok4 bool
-
 			var wg sync.WaitGroup
 			wg.Add(8)
 
 			go func() {
 				img1, err1 = raster.GeneratePageImage(1, 1024, 0)
-				if img1 != nil {
-					ok1 = true
-				}
 				wg.Done()
 			}()
 
 			go func() {
 				img2, err2 = raster.GeneratePageImage(1, 1024, 0)
-				if img2 != nil {
-					ok2 = true
-				}
 				wg.Done()
 			}()
 
 			go func() {
 				img3, err3 = raster.GeneratePageImage(2, 1024, 0)
-				if img3 != nil {
-					ok3 = true
-				}
 				wg.Done()
 			}()
 
 			go func() {
 				img4, err4 = raster.GeneratePageImage(2, 1024, 0)
-				if img4 != nil {
-					ok4 = true
-				}
 				wg.Done()
 			}()
 
@@ -412,16 +394,16 @@ func Test_Processing(t *testing.T) {
 
 			wg.Wait()
 
-			// Checking these is really slow... about 1 second each
-			So(ok1, ShouldBeTrue)
-			So(ok2, ShouldBeTrue)
-			So(ok3, ShouldBeTrue)
-			So(ok4, ShouldBeTrue)
-
 			So(err1, ShouldBeNil)
 			So(err2, ShouldBeNil)
 			So(err3, ShouldBeNil)
 			So(err4, ShouldBeNil)
+
+			// Checking these using ShouldNotBeNil is really slow...
+			So(img1 != nil, ShouldBeTrue)
+			So(img2 != nil, ShouldBeTrue)
+			So(img3 != nil, ShouldBeTrue)
+			So(img4 != nil, ShouldBeTrue)
 
 			raster.Stop()
 		})

--- a/render_tool/render_tool.go
+++ b/render_tool/render_tool.go
@@ -31,7 +31,7 @@ func main() {
 		log.Fatalf("Failed to initialize the renderer: %s", err)
 	}
 
-	img, err := raster.GeneratePage(*page, *size, *scale)
+	img, err := raster.GeneratePageImage(*page, *size, *scale)
 	if err != nil {
 		log.Fatalf("Render error: %s", err)
 	}

--- a/render_tool/render_tool.go
+++ b/render_tool/render_tool.go
@@ -10,37 +10,83 @@ import (
 	"github.com/Nitro/lazypdf"
 )
 
+type rasterType int
+
+const (
+	RasterPNG rasterType = iota
+	RasterSVG
+)
+
 var (
 	pdf   = kingpin.Arg("pdf", "PDF file").Required().String()
 	page  = kingpin.Flag("page", "page").Default("1").Short('p').Int()
 	size  = kingpin.Flag("size", "size").Default("0").Short('s').Int()
 	scale = kingpin.Flag("scale", "scale").Default("1.5").Short('S').Float()
 	out   = kingpin.Flag("out", "out").Default("").Short('o').String()
+	ext   = kingpin.Flag("ext", "ext").Default("png").Short('e').String()
 )
+
+func getRasterType(ext string) rasterType {
+	switch ext {
+	case "png":
+		return RasterPNG
+	case "svg":
+		return RasterSVG
+	}
+
+	return RasterPNG
+}
+
+func outputWriter(writer func(f *os.File)) {
+	f, err := os.Create(*out)
+	if err != nil {
+		log.Fatalf("IO error: %s", err)
+	}
+	defer f.Close()
+
+	writer(f)
+}
 
 func main() {
 	kingpin.Parse()
 
 	if *out == "" {
-		*out = *pdf + ".png"
+		*out = *pdf + "." + *ext
 	}
 
 	raster := lazypdf.NewRasterizer(*pdf)
 	err := raster.Run()
 	if err != nil {
-		log.Fatalf("Failed to initialize the renderer: %s", err)
+		log.Fatalf("Failed to initialize the rasteriser: %s", err)
 	}
 
-	img, err := raster.GeneratePageImage(*page, *size, *scale)
-	if err != nil {
-		log.Fatalf("Render error: %s", err)
-	}
+	switch getRasterType(*ext) {
+	case RasterPNG:
+		img, err := raster.GeneratePageImage(*page, *size, *scale)
+		if err != nil {
+			log.Fatalf("Raster error: %s", err)
+		}
 
-	f, err := os.Create(*out)
-	if err != nil {
-		log.Fatalf("IO error: %s", err)
-	}
+		outputWriter(func(f *os.File) {
+			err = png.Encode(f, img)
+			if err != nil {
+				log.Fatalf("Failed to write image to file: %s", err)
+			}
+		})
 
-	defer f.Close()
-	png.Encode(f, img)
+	case RasterSVG:
+		svgData, err := raster.GeneratePageSVG(*page, *size, *scale)
+		if err != nil {
+			log.Fatalf("Raster error: %s", err)
+		}
+
+		outputWriter(func(f *os.File) {
+			_, err = f.WriteString(svgData)
+			if err != nil {
+				log.Fatalf("Failed to write SVG to file: %s", err)
+			}
+		})
+	default:
+		log.Fatalf("Can't raster to: %s", *ext)
+	}
 }

--- a/render_tool/render_tool.go
+++ b/render_tool/render_tool.go
@@ -81,7 +81,7 @@ func main() {
 		}
 
 		outputWriter(func(f *os.File) {
-			_, err = f.WriteString(svgData)
+			_, err = f.Write(svgData)
 			if err != nil {
 				log.Fatalf("Failed to write SVG to file: %s", err)
 			}


### PR DESCRIPTION
This PR is a new version of #5, with the aim of integrating the render to SVG functionality into the `Rasterizer` workflow. While the initial prototype works well (thanks @relistan for helping me write that one!), it has a few shortcomings which this code aims to address:
- simplified C code and moved it completely to Go. This code https://github.com/gen2brain/go-fitz/blob/297d6b6088086f9eb8f2c5be84046f9acdc5789a/fitz.go#L271-L304 helped me get a better idea of what C functions need to be called. The initial prototype was inspired from https://github.com/ArtifexSoftware/mupdf/blob/7cb9579804102ea39ef76d237144b57331766df1/source/tools/mudraw.c which is a bit more convoluted
- changed the public API a bit to support the new functionality and other future extensions
- used `fz_buffer_storage` to extract the SVG payload bytes instead of doing `C.GoBytes(unsafe.Pointer(fzBuf.data), C.int(fzBuf.len))`, which relies on implementation details instead of a public API function. Note that we could also have used `fz_string_from_buffer` to get back a string, but since the `io.Writer` `Write` method works with byte arrays, converting from string back to `[]byte` might create an extra copy
- updated the render tool to support SVG output