### PR TITLE
Make scale factor computation idempotent

### DIFF
--- a/faster_raster_test.go
+++ b/faster_raster_test.go
@@ -115,14 +115,14 @@ func Test_scalePage(t *testing.T) {
 			raster.Stop()
 		})
 
-		Convey("uses LandscapeScale if any page is landscape", func() {
+		Convey("uses PortraitScale if any page is landscape", func() {
 			raster := NewRasterizer("fixtures/mixed-sample.pdf", 1)
 			err := raster.Run()
 			So(err, ShouldBeNil)
 			img, err := raster.GeneratePageImage(context.Background(), 2, 0, 0)
 
 			So(err, ShouldBeNil)
-			So(img.Bounds().Max.X, ShouldEqual, 612)
+			So(img.Bounds().Max.X, ShouldEqual, 918)
 
 			raster.Stop()
 		})


### PR DESCRIPTION
- The scale factor no longer needs to be changed if the document contains a landscape page
- The previous code was incorrect, since it would recompute the scale for a page on subsequent requests for the same page because r.scaleFactor != 0 after the initial request