### PR TITLE
Refactor cgo build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.swp
 *.swo
-/mupdf*
 render_tool/render_tool

--- a/README.md
+++ b/README.md
@@ -18,21 +18,4 @@ on either Linux or OSX.
 Installing
 ----------
 
-You cannot simply `go get` this library. It pulls in and links against C code
-which is external to this repository for licensing reasons (the MuPDF library
-is AGPL). Thus, in order to build this library, you need to run the `build`
-shell script to pull down and compile MuPDF first.
-
-Anything that you then want to link against this library will need to use the
-correct Cgo configuration.  That should look like:
-
-```go
-// #cgo CFLAGS: -I. -I./mupdf-1.12.0-source/include -I./mupdf-1.12.0-source/include/mupdf -I./mupdf-1.12.0-source/thirdparty/openjpeg -I./mupdf-1.12.0-source/thirdparty/jbig2dec -I./mupdf-1.12.0-source/thirdparty/zlib -I./mupdf-1.12.0-source/thirdparty/jpeg -I./mupdf-1.12.0-source/thirdparty/freetype -g
-// #cgo LDFLAGS: -L./mupdf-1.12.0-source/build/release -lmupdf -lmupdfthird -lm -ljbig2dec -lz -lfreetype -ljpeg -lcrypto -lpthread
-// #include <faster_raster.h>
-import "C"
-```
-
-`<relative path>` in this case should be the relative location of this library
-to your project. If you are building a Go project under the `github.com/Nitro`
-folder, this would usually be `../lazypdf`.
+The only requirement is to build first MuPDF with the `./build` script.

--- a/build
+++ b/build
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Elevate execution privilege.
+[ "$UID" -eq 0 ] || exec sudo bash "$0" "$@"
+
 if [ ! -z ${SHALLOW_CLONE} ]; then
 	# Can't use --shallow-submodules because some bug in either Git or in the
 	# mupdf submodule setup makes the clone command fail.
@@ -8,20 +11,13 @@ fi
 
 MUPDF_VERSION="1.16.1"
 
-if [[ ! -d mupdf ]]; then
+if [[ ! -d /opt/mupdf ]]; then
 	echo "Downloading muPDF..."
 	# Setting -j0 clones submodules with as many parallel jobs as possible
-	git clone --branch ${MUPDF_VERSION} ${SHALLOW_CLONE} --recurse-submodules=thirdparty -j0 https://github.com/ArtifexSoftware/mupdf.git
+	git clone --branch ${MUPDF_VERSION} ${SHALLOW_CLONE} --recurse-submodules=thirdparty -j0 https://github.com/ArtifexSoftware/mupdf.git /opt/mupdf
 fi
 
 echo "Building muPDF..."
 # Pass -j to build using as many cores as possible
-(cd mupdf; XCFLAGS="-g" make -j libs)
-
-# Newer OSX needs an include path for OpenSSL
-if [[ `uname -s` == "Darwin" ]]; then
-	export CGO_LDFLAGS="-L/usr/local/opt/openssl/lib"
-fi
-
-echo "Fetching Go dependencies and compiling code..."
-go get -t ./...
+(cd /opt/mupdf; XCFLAGS="-g" make -j libs)
+echo $MUPDF_VERSION >> /opt/mupdf/version

--- a/faster_raster.go
+++ b/faster_raster.go
@@ -14,8 +14,17 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// #cgo CFLAGS: -I. -I./mupdf/include -I./mupdf/include/mupdf -I./mupdf/thirdparty/openjpeg -I./mupdf/thirdparty/jbig2dec -I./mupdf/thirdparty/zlib -I./mupdf/thirdparty/jpeg -I./mupdf/thirdparty/freetype
-// #cgo LDFLAGS: -L./mupdf/build/release -lmupdf -lmupdf-third -lm -lcrypto -lpthread
+// #cgo CFLAGS: -I/opt/mupdf/include
+// #cgo CFLAGS: -I/opt/mupdf/include/mupdf
+// #cgo CFLAGS: -I/opt/mupdf/thirdparty/openjpeg
+// #cgo CFLAGS: -I/opt/mupdf/thirdparty/jbig2dec
+// #cgo CFLAGS: -I/opt/mupdf/thirdparty/zlib
+// #cgo CFLAGS: -I/opt/mupdf/thirdparty/jpeg
+// #cgo CFLAGS: -I/opt/mupdf/thirdparty/freetype
+//
+// #cgo LDFLAGS: -L/opt/mupdf/build/release -lmupdf -lmupdf-third -lm -lcrypto -lpthread
+// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl/lib
+//
 // #include <faster_raster.h>
 import "C"
 

--- a/go.sum
+++ b/go.sum
@@ -18,7 +18,6 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=


### PR DESCRIPTION
This package is Go gettable now. The only requirement is to build/install mupdf first. 

Depends on #35.