### PR TITLE
Fix black boxes during render

### DIFF
--- a/faster_raster.go
+++ b/faster_raster.go
@@ -475,7 +475,7 @@ func (r *Rasterizer) processOne(req *RasterRequest) {
 
 	err := req.runCancellableOperation(r.Filename,
 		func(cookie *C.fz_cookie) {
-			C.fz_run_page(ctx, page, device, C.fz_identity, cookie)
+			C.fz_run_page_contents(ctx, page, device, C.fz_identity, cookie)
 		},
 	)
 	C.fz_close_device(ctx, device)
@@ -531,7 +531,7 @@ func (r *Rasterizer) renderToSVG(ctx *C.struct_fz_context_s, page *C.fz_page, bo
 
 	err := req.runCancellableOperation(r.Filename,
 		func(cookie *C.fz_cookie) {
-			C.fz_run_page(ctx, page, device, C.fz_identity, cookie)
+			C.fz_run_page_contents(ctx, page, device, C.fz_identity, cookie)
 		},
 	)
 


### PR DESCRIPTION
We have an open issue regards a problem at Nitro Cloud where some documents are being rendered with a black box. 

@AtnNn found the problem, it was related to annotations at the PDF and MuPDF was rendering those annotations. Updating the render from `fz_run_page` to `fz_run_page_contents` as he suggested solved the problem.