### PR TITLE
Enable async cgo processing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,18 @@ jobs:
           go test -race -cover -covermode=atomic -json | tparse -all
           go test -race -bench .
 
+      - name: Install valgrind
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes valgrind
+
+      - name: Test & valgrind
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          go test -c .
+          valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./lazypdf.test
+
       - name: Go golangci-lint
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/DataDog/datadog-go v4.7.0+incompatible // indirect
 	github.com/Microsoft/go-winio v0.5.0 // indirect
-	github.com/google/uuid v1.2.0 // indirect
+	github.com/google/uuid v1.2.0
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"runtime"
 	"sync"
 	"unsafe"
 
@@ -44,7 +43,6 @@ type pageCountOutput struct {
 func init() {
 	saveToPNGState = make(map[string]saveToPNGOutput)
 	pageCountState = make(map[string]pageCountOutput)
-	C.init_state(C.ulong(runtime.NumCPU()))
 }
 
 // SaveToPNG is used to convert a page from a PDF file to PNG.
@@ -179,9 +177,4 @@ func cleanPageCountState(id string) {
 	pageCountMutex.Lock()
 	delete(pageCountState, id)
 	pageCountMutex.Unlock()
-}
-
-//export fatal
-func fatal(msg *C.char) {
-	panic(C.GoString(msg))
 }

--- a/main.h
+++ b/main.h
@@ -1,19 +1,39 @@
 #ifndef MAIN_H
 #define MAIN_H
 
+#include <pthread.h>
 #include "pdf.h"
 
-typedef const char cchar;
+typedef struct {
+	char *id;
+	int page;
+	int width;
+	float scale;
+	const unsigned char *payload;
+	size_t payload_length;
+} SaveToPNGInput;
 
 typedef struct {
-	fz_context *context;
-	fz_buffer *buffer;
+	char *id;
+	char *data;
 	size_t len;
-	const char *data;
-} result;
+	const char *error;
+} SaveToPNGOutput;
 
-int page_count(const unsigned char *payload, size_t payload_length);
-result *save_to_png(int page_number, int width, float scale, const unsigned char *payload, size_t payload_length);
-void drop_result(result *r);
+typedef struct {
+	char *id;
+	const unsigned char *payload;
+	size_t payload_length;
+} PageCountInput;
+
+typedef struct {
+	char *id;
+	int count;
+	const char *error;
+} PageCountOutput;
+
+void init_state(size_t lock_quantity);
+void page_count(PageCountInput *input);
+void save_to_png(SaveToPNGInput *input);
 
 #endif

--- a/main.h
+++ b/main.h
@@ -1,7 +1,6 @@
 #ifndef MAIN_H
 #define MAIN_H
 
-#include <pthread.h>
 #include "pdf.h"
 
 typedef struct {
@@ -32,7 +31,6 @@ typedef struct {
 	const char *error;
 } PageCountOutput;
 
-void init_state(size_t lock_quantity);
 void page_count(PageCountInput *input);
 void save_to_png(SaveToPNGInput *input);
 


### PR DESCRIPTION
From now on the heavy cgo operations are running on dedicated threads to not block Go ones. This change will reduce dramatically the latency on lazyraster.