### PR TITLE
Add global context

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,10 +13,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"unsafe"
 
 	ddTracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
+
+func init() {
+	C.init(C.ulong(runtime.NumCPU()))
+}
 
 // SaveToPNG is used to convert a page from a PDF file to PNG.
 func SaveToPNG(ctx context.Context, page, width uint16, scale float32, rawPayload io.Reader, output io.Writer) error {

--- a/main.h
+++ b/main.h
@@ -27,6 +27,7 @@ typedef struct {
 	const char *error;
 } save_to_png_output;
 
+void init(size_t lock_quantity);
 page_count_output *page_count(page_count_input *input);
 save_to_png_output *save_to_png(save_to_png_input *input);
 

--- a/misc/golangci/config.yml
+++ b/misc/golangci/config.yml
@@ -6,7 +6,6 @@ linters:
     - dupl
     - errcheck
     - gochecknoglobals
-    - gochecknoinits
     - goconst
     - gocritic
     - gocyclo


### PR DESCRIPTION
MuPDF recommends using a global context in the case of multithreading.

```	
	We strongly recommend that fz_new_context is called just once,
	and fz_clone_context is called to generate new contexts from
	that. This will automatically ensure that the same locking
	mechanism is used in all MuPDF instances. For now, we do support
	multiple completely independent contexts being created using
	repeated calls to fz_new_context, but these MUST share the
	same fz_locks_context (or at least depend upon the same underlying
	locks). The facility to create different independent contexts
	may be removed in future.
```
https://github.com/ArtifexSoftware/mupdf/blob/master/docs/coding-overview.html