### PR TITLE
CW-2450 - Improve SavePDF Performance in Core PDF Handler

### DIFF
--- a/pdf_handler.c
+++ b/pdf_handler.c
@@ -609,10 +609,12 @@ savePDFOutput save_pdf(pdfDocument document, const char *file_path) {
 
         pdf_write_options options = pdf_default_write_options;
         options.do_compress = 1;
-        options.do_compress_images = 1;
-        options.do_compress_fonts = 1;
-        options.do_garbage = 3;
-
+        options.do_compress_images = 0;   // avoid recompressing image streams
+        options.do_compress_fonts = 0;    // keep original font streams
+        options.do_garbage = 1;           // remove dead objects only (not full rewrite)
+        options.do_linear = 0;            // skip linearization (web optimization)
+        options.do_incremental = 0;       // write clean file, but not in-place update
+        
         pdf_save_document(ctx, doc, file_path, &options);
     }
     fz_catch(ctx) {


### PR DESCRIPTION
## Links



## Description
The current SavePDF implementation uses aggressive compression and full garbage collection, which results in:

- On faulty.pdf
  - Save time improved from ~727 ms → ~49 ms (~14× faster)
  - Memory reduced from ~500 B/op → ~77 B/op (~6.5× less)
- On other files
  - Save time: Improved slightly (~2–8%)
  - Save time: Slightly slower in some cases (~1.5–3%)

This change significantly improves worst-case performance while maintaining or slightly improving average-case speed and memory usage. 