### PR TITLE
CW-2477 - Optimize wrapPageContents to avoid redundant analysis on each annotation

### DIFF
--- a/pdf_handler.c
+++ b/pdf_handler.c
@@ -665,3 +665,31 @@ saveToPNGOutput save_to_png_file(pdfDocument document, saveToPNGInput input) {
     return output;
 }
 
+wrapPageOutput wrap_page_contents_for_page(pdfDocument document, int page_number) {
+    wrapPageOutput output = { .error = NULL };
+    pdf_document *pdf = NULL;
+    pdf_page *page = NULL;
+    
+    fz_context *ctx = fz_clone_context(global_ctx);
+    if (!ctx) {
+        output.error = strdup("Context clone failed");
+        return output;
+    }
+
+    fz_var(pdf);
+    fz_try(ctx) {
+        pdf = (pdf_document *)document.handle;
+        page = pdf_load_page(ctx, pdf, page_number);
+        wrap_page_contents(ctx, page);
+    }
+    fz_always(ctx) {
+        fz_drop_page(ctx, &page->super);
+    }
+    fz_catch(ctx) {
+        output.error = strdup(fz_caught_message(ctx));
+    }
+
+    fz_drop_context(ctx);
+    return output;
+}
+

--- a/pdf_handler.go
+++ b/pdf_handler.go
@@ -52,8 +52,8 @@ func NewPdfHandlerWithLogger(logger *slog.Logger) *PdfHandler {
 type PdfDocument struct {
 	handle       C.uintptr_t
 	file         string
-	wrappedPages map[int]bool 
-	mu           sync.RWMutex 
+	wrappedPages map[int]bool
+	mu           sync.RWMutex
 }
 
 type Location struct {
@@ -290,22 +290,13 @@ func (p *PdfHandler) GetPageSizeWithContext(ctx context.Context, document PdfDoc
 	return pageSize, nil
 }
 
-
 func (p *PdfHandler) wrapPageContents(document *PdfDocument, pageNum int) error {
-	
-	document.mu.RLock()
-	if document.wrappedPages[pageNum] {
-		document.mu.RUnlock()
-		return nil // Already wrapped, no need to call C function
-	}
-	document.mu.RUnlock()
-
+	// Lock the entire function
 	document.mu.Lock()
 	defer document.mu.Unlock()
 
-	// Double-check in case another goroutine wrapped it while we were waiting for the lock
 	if document.wrappedPages[pageNum] {
-		return nil
+		return nil // Already wrapped, no need to call C function
 	}
 
 	pdf := C.pdfDocument{

--- a/pdf_handler.go
+++ b/pdf_handler.go
@@ -322,12 +322,6 @@ func (p *PdfHandler) AddImageToPage(document PdfDocument, params ImageParams) (e
 	span, ctx := ddTracer.StartSpanFromContext(p.ctx, "PdfHandler.AddImageToPage")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 
-	// Wrap page contents before adding image
-	err = p.wrapPageContents(ctx, &document, params.Page)
-	if err != nil {
-		return fmt.Errorf("failure at wrapPageContents in AddImageToPage: %s", err)
-	}
-
 	cImagePath := C.CString(params.ImagePath)
 	defer C.free(unsafe.Pointer(cImagePath))
 
@@ -356,6 +350,12 @@ func (p *PdfHandler) AddImageToPage(document PdfDocument, params ImageParams) (e
 		y:      C.float(y),
 		width:  C.float(width),
 		height: C.float(height),
+	}
+
+	// Wrap page contents before adding image
+	err = p.wrapPageContents(ctx, &document, params.Page)
+	if err != nil {
+		return fmt.Errorf("failure at the AddImageToPage function:: %s", err)
 	}
 
 	// Measure C function call performance
@@ -495,12 +495,6 @@ func (p *PdfHandler) AddTextBoxToPage(document PdfDocument, params TextParams) (
 	span, ctx := ddTracer.StartSpanFromContext(p.ctx, "PdfHandler.AddTextBoxToPage")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 
-	// Wrap page contents before adding text
-	err = p.wrapPageContents(ctx, &document, params.Page)
-	if err != nil {
-		return fmt.Errorf("failure at wrapPageContents in AddTextBoxToPage: %s", err)
-	}
-
 	fontPath, descender, err := p.getFontAttributes(ctx, params.Font.Family, params.Font.Size)
 	if err != nil {
 		return fmt.Errorf("failure at PdfHandler AddTextBoxToPage function: failed to find font path for %q", params.Font.Family)
@@ -547,6 +541,12 @@ func (p *PdfHandler) AddTextBoxToPage(document PdfDocument, params TextParams) (
 		font_size:   C.float(params.Font.Size),
 	}
 
+	// Wrap page contents before adding text
+	err = p.wrapPageContents(ctx, &document, params.Page)
+	if err != nil {
+		return fmt.Errorf("failure at the AddTextBoxToPage function: %s", err)
+	}
+
 	// Measure C function call performance
 	cCallStart := time.Now()
 	output := C.add_text_to_page(pdf, input)
@@ -576,12 +576,6 @@ func (p *PdfHandler) AddCheckboxToPage(document PdfDocument, params CheckboxPara
 	span, ctx := ddTracer.StartSpanFromContext(p.ctx, "PdfHandler.AddCheckboxToPage")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 
-	// Wrap page contents before adding checkbox
-	err = p.wrapPageContents(ctx, &document, params.Page)
-	if err != nil {
-		return fmt.Errorf("failure at wrapPageContents in AddCheckboxToPage: %s", err)
-	}
-
 	pdf := C.pdfDocument{
 		handle: document.handle,
 		error:  nil,
@@ -607,6 +601,12 @@ func (p *PdfHandler) AddCheckboxToPage(document PdfDocument, params CheckboxPara
 		y:      C.float(y),
 		width:  C.float(width),
 		height: C.float(height),
+	}
+
+	// Wrap page contents before adding checkbox
+	err = p.wrapPageContents(ctx, &document, params.Page)
+	if err != nil {
+		return fmt.Errorf("failure at the AddCheckboxToPage function: %s", err)
 	}
 
 	// Measure C function call performance

--- a/pdf_handler.h
+++ b/pdf_handler.h
@@ -103,4 +103,10 @@ typedef struct {
 
 saveToPNGOutput save_to_png_file(pdfDocument document, saveToPNGInput input);
 
+typedef struct {
+    char *error; // NULL if successful
+} wrapPageOutput;
+
+wrapPageOutput wrap_page_contents_for_page(pdfDocument document, int page);
+
 #endif

--- a/pdf_handler_test.go
+++ b/pdf_handler_test.go
@@ -1305,3 +1305,113 @@ func benchmarkPdfHandlerSaveToPNGRunner(page uint16, b *testing.B) {
 		require.NoError(b, err)
 	}
 }
+
+func TestPdfHandler_WrapPageContents(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	handler := NewPdfHandler(context.Background(), logger)
+
+	file, err := os.Open("testdata/pdf_handler_sample.pdf")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, file.Close()) }()
+
+	document, err := handler.OpenPDF(file)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+
+	// Initially, no pages should be wrapped
+	require.False(t, document.wrappedPages[0])
+
+	// First call to wrapPageContents for page 0 should mark it as wrapped
+	err = handler.wrapPageContents(context.Background(), &document, 0)
+	require.NoError(t, err)
+	require.True(t, document.wrappedPages[0])
+
+	// Second call to wrapPageContents for page 0 should not error and page should still be marked as wrapped
+	err = handler.wrapPageContents(context.Background(), &document, 0)
+	require.NoError(t, err)
+	require.True(t, document.wrappedPages[0])
+
+	// Test that other pages are not affected
+	require.False(t, document.wrappedPages[1])
+	require.False(t, document.wrappedPages[2])
+}
+
+func TestPdfHandler_WrapPageContents_InvalidPage(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	handler := NewPdfHandler(context.Background(), logger)
+
+	file, err := os.Open("testdata/pdf_handler_sample.pdf")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, file.Close()) }()
+
+	document, err := handler.OpenPDF(file)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+
+	// Call wrapPageContents with invalid page number should return error
+	err = handler.wrapPageContents(context.Background(), &document, 2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failure at wrap_page_contents_for_page")
+}
+
+func TestPdfHandler_WrapPageContents_Integration(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	handler := NewPdfHandler(context.Background(), logger)
+
+	file, err := os.Open("testdata/sample.pdf")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, file.Close()) }()
+
+	document, err := handler.OpenPDF(file)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+
+	// Test that annotation functions automatically wrap page contents
+	require.False(t, document.wrappedPages[0])
+	textParams := TextParams{
+		Value:    "Test Text",
+		Page:     0,
+		Location: Location{X: 0.1, Y: 0.1},
+		Size:     Size{Width: 0.3, Height: 0.05},
+		Font: struct {
+			Family string
+			Size   float64
+		}{
+			Family: "Times New Roman",
+			Size:   12,
+		},
+	}
+	err = handler.AddTextBoxToPage(document, textParams)
+	require.NoError(t, err)
+	require.True(t, document.wrappedPages[0])
+
+	// Test that annotation functions automatically wrap page contents
+	require.False(t, document.wrappedPages[1])
+	imageParams := ImageParams{
+		Page:      1,
+		Location:  Location{X: 0.5, Y: 0.5},
+		Size:      Size{Width: 0.2, Height: 0.2},
+		ImagePath: "testdata/test_signature.png",
+	}
+	err = handler.AddImageToPage(document, imageParams)
+	require.NoError(t, err)
+	require.True(t, document.wrappedPages[1]) // Should still be true
+
+	// Test that annotation functions automatically wrap page contents
+	require.False(t, document.wrappedPages[2])
+	checkboxParams := CheckboxParams{
+		Value:    true,
+		Page:     2,
+		Location: Location{X: 0.7, Y: 0.7},
+		Size:     Size{Width: 0.05, Height: 0.05},
+	}
+	err = handler.AddCheckboxToPage(document, checkboxParams)
+	require.NoError(t, err)
+	require.True(t, document.wrappedPages[2])
+}


### PR DESCRIPTION
Currently, each call to AddAnnotation (e.g., AddText, AddImage, AddCheckbox) triggers a call to wrapPageContents, which performs a costly analysis to rebalance the graphic states of the page. While this is necessary once, doing it repeatedly causes significant performance degradation—especially on large documents.