### PR TITLE
fix passing a struct by value that contains a sync.RWMutex

### DIFF
--- a/pdf_handler.go
+++ b/pdf_handler.go
@@ -160,7 +160,7 @@ func savePayloadToTempFile(ctx context.Context, r io.Reader) (filename string, e
 }
 
 // Percentages relative to page dimensions to PDF Point
-func (p *PdfHandler) LocationSizeToPdfPoints(ctx context.Context, document PdfDocument, page int, x, y, width, height float64) (float64, float64, float64, float64, error) {
+func (p *PdfHandler) LocationSizeToPdfPoints(ctx context.Context, document *PdfDocument, page int, x, y, width, height float64) (float64, float64, float64, float64, error) {
 	span, _ := ddTracer.StartSpanFromContext(ctx, "PdfHandler.LocationSizeToPdfPoints")
 	defer span.Finish()
 
@@ -215,7 +215,7 @@ func (p *PdfHandler) OpenPDF(rawPayload io.Reader) (document PdfDocument, err er
 	return pdf, nil
 }
 
-func (p *PdfHandler) ClosePDF(document PdfDocument) (err error) {
+func (p *PdfHandler) ClosePDF(document *PdfDocument) (err error) {
 	span, _ := ddTracer.StartSpanFromContext(p.ctx, "PdfHandler.ClosePDF")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 
@@ -248,14 +248,14 @@ func (p *PdfHandler) ClosePDF(document PdfDocument) (err error) {
 	return nil
 }
 
-func (p *PdfHandler) GetPageSize(document PdfDocument, page int) (pageSize PageSize, err error) {
+func (p *PdfHandler) GetPageSize(document *PdfDocument, page int) (pageSize PageSize, err error) {
 	span, ctx := ddTracer.StartSpanFromContext(p.ctx, "PdfHandler.GetPageSize")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 
 	return p.GetPageSizeWithContext(ctx, document, page)
 }
 
-func (p *PdfHandler) GetPageSizeWithContext(ctx context.Context, document PdfDocument, page int) (pageSize PageSize, err error) {
+func (p *PdfHandler) GetPageSizeWithContext(ctx context.Context, document *PdfDocument, page int) (pageSize PageSize, err error) {
 	span, _ := ddTracer.StartSpanFromContext(ctx, "PdfHandler.GetPageSize")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 
@@ -324,7 +324,7 @@ func (p *PdfHandler) wrapPageContents(ctx context.Context, document *PdfDocument
 	return nil
 }
 
-func (p *PdfHandler) AddImageToPage(document PdfDocument, params ImageParams) (err error) {
+func (p *PdfHandler) AddImageToPage(document *PdfDocument, params ImageParams) (err error) {
 	span, ctx := ddTracer.StartSpanFromContext(p.ctx, "PdfHandler.AddImageToPage")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 
@@ -358,7 +358,7 @@ func (p *PdfHandler) AddImageToPage(document PdfDocument, params ImageParams) (e
 		height: C.float(height),
 	}
 
-	err = p.wrapPageContents(ctx, &document, params.Page)
+	err = p.wrapPageContents(ctx, document, params.Page)
 	if err != nil {
 		return fmt.Errorf("failure at the AddImageToPage function:: %s", err)
 	}
@@ -494,7 +494,7 @@ func (p *PdfHandler) getFontAttributes(ctx context.Context, font string, fontSiz
 	return "", 0, fmt.Errorf("font %q not found", font)
 }
 
-func (p *PdfHandler) AddTextBoxToPage(document PdfDocument, params TextParams) (err error) {
+func (p *PdfHandler) AddTextBoxToPage(document *PdfDocument, params TextParams) (err error) {
 	span, ctx := ddTracer.StartSpanFromContext(p.ctx, "PdfHandler.AddTextBoxToPage")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 
@@ -544,7 +544,7 @@ func (p *PdfHandler) AddTextBoxToPage(document PdfDocument, params TextParams) (
 		font_size:   C.float(params.Font.Size),
 	}
 
-	err = p.wrapPageContents(ctx, &document, params.Page)
+	err = p.wrapPageContents(ctx, document, params.Page)
 	if err != nil {
 		return fmt.Errorf("failure at the AddTextBoxToPage function: %s", err)
 	}
@@ -572,7 +572,7 @@ func boolToInt(value bool) int {
 	return 0
 }
 
-func (p *PdfHandler) AddCheckboxToPage(document PdfDocument, params CheckboxParams) (err error) {
+func (p *PdfHandler) AddCheckboxToPage(document *PdfDocument, params CheckboxParams) (err error) {
 	span, ctx := ddTracer.StartSpanFromContext(p.ctx, "PdfHandler.AddCheckboxToPage")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 
@@ -603,7 +603,7 @@ func (p *PdfHandler) AddCheckboxToPage(document PdfDocument, params CheckboxPara
 		height: C.float(height),
 	}
 
-	err = p.wrapPageContents(ctx, &document, params.Page)
+	err = p.wrapPageContents(ctx, document, params.Page)
 	if err != nil {
 		return fmt.Errorf("failure at the AddCheckboxToPage function: %s", err)
 	}
@@ -624,7 +624,7 @@ func (p *PdfHandler) AddCheckboxToPage(document PdfDocument, params CheckboxPara
 	return nil
 }
 
-func (p *PdfHandler) SavePDF(document PdfDocument, filePath string) (err error) {
+func (p *PdfHandler) SavePDF(document *PdfDocument, filePath string) (err error) {
 	span, _ := ddTracer.StartSpanFromContext(p.ctx, "PdfHandler.SavePDF")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 

--- a/pdf_handler_test.go
+++ b/pdf_handler_test.go
@@ -32,7 +32,7 @@ func TestPdfHandler_OpenPDF(t *testing.T) {
 	if document.handle == 0 {
 		t.Fatalf("handle is null:")
 	}
-	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 }
 
 func TestPdfHandler_OpenInvalidFile(t *testing.T) {
@@ -76,7 +76,7 @@ func TestPdfHandler_TestClosePDF(t *testing.T) {
 		t.Fatalf("OpenPDF: %v", err)
 	}
 
-	if err := handler.ClosePDF(document); err != nil {
+	if err := handler.ClosePDF(&document); err != nil {
 		t.Fatalf("ClosePDF: %v", err)
 	}
 }
@@ -94,12 +94,12 @@ func TestPdfHandler_LocationSizeToPdfPoints_InvalidPage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenPDF: %v", err)
 	}
-	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 	//nolint:dogsled // we only care about the error
 	_, _, _, _, err = handler.LocationSizeToPdfPoints(
 		context.Background(),
-		document,
+		&document,
 		2,
 		0,
 		0,
@@ -165,7 +165,7 @@ func TestPdfHandler_LocationSizeToPdfPoints_InvalidInputPercentages(t *testing.T
 			handler := setupPdfHandler(t)
 			document := openTestPDF(t, tt.path)
 
-			_, _, _, _, err := handler.LocationSizeToPdfPoints(context.Background(), document, 0, tt.x, tt.y, tt.width, tt.height)
+			_, _, _, _, err := handler.LocationSizeToPdfPoints(context.Background(), &document, 0, tt.x, tt.y, tt.width, tt.height)
 			require.Error(t, err)
 			require.EqualError(t, err, tt.expectedError)
 		})
@@ -234,7 +234,7 @@ func TestPdfHandler_TestLocationSizeToPdfPoints(t *testing.T) {
 
 			X, Y, Width, Height, err := handler.LocationSizeToPdfPoints(
 				context.Background(),
-				handle,
+				&handle,
 				0,
 				tt.X,
 				tt.Y,
@@ -265,9 +265,9 @@ func TestPdfHandler_GetPageSize_InvalidPage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenPDF: %v", err)
 	}
-	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
-	_, err = handler.GetPageSize(document, 2)
+	_, err = handler.GetPageSize(&document, 2)
 	require.Error(t, err)
 	require.Equal(t, "failure at the C/MuPDF get_page_size function: invalid page number: 3", err.Error())
 }
@@ -293,7 +293,7 @@ func TestPdfHandler_TestGetPageSize(t *testing.T) {
 			handler := setupPdfHandler(t)
 			document := openTestPDF(t, tt.path)
 
-			size, err := handler.GetPageSize(document, 0)
+			size, err := handler.GetPageSize(&document, 0)
 			require.NoError(t, err, "Failed to get page size for file: %s", tt.path)
 
 			require.InDelta(t, tt.expectedWidth, size.Width, 0.1, "Unexpected width for file: %s", tt.path)
@@ -321,7 +321,7 @@ func openTestPDF(t *testing.T, filePath string) PdfDocument {
 
 	t.Cleanup(func() {
 		require.NoError(t, file.Close())
-		require.NoError(t, handler.ClosePDF(document))
+		require.NoError(t, handler.ClosePDF(&document))
 	})
 
 	return document
@@ -330,10 +330,10 @@ func openTestPDF(t *testing.T, filePath string) PdfDocument {
 func addImageAndSave(t *testing.T, handler PdfHandler, document PdfDocument, params ImageParams, outputPath string) {
 	t.Helper()
 
-	err := handler.AddImageToPage(document, params)
+	err := handler.AddImageToPage(&document, params)
 	require.NoError(t, err, "failed to add image")
 
-	err = handler.SavePDF(document, outputPath)
+	err = handler.SavePDF(&document, outputPath)
 	require.NoError(t, err, "failed to save PDF")
 }
 
@@ -442,7 +442,7 @@ func TestPdfHandler_AddImageToPage_InvalidPage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenPDF: %v", err)
 	}
-	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 	params := ImageParams{
 		Page: 13,
@@ -457,7 +457,7 @@ func TestPdfHandler_AddImageToPage_InvalidPage(t *testing.T) {
 		ImagePath: "testdata/test_signature.png",
 	}
 
-	err = handler.AddImageToPage(document, params)
+	err = handler.AddImageToPage(&document, params)
 	require.Error(t, err)
 	require.Equal(t, "failure at the AddImageToPage function: failed to get page size: failure at the C/MuPDF get_page_size function: invalid page number: 14", err.Error())
 }
@@ -476,7 +476,7 @@ func TestPdfHandler_AddImageToPage_InvalidImage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenPDF: %v", err)
 	}
-	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 	params := ImageParams{
 		Page: 0,
@@ -491,7 +491,7 @@ func TestPdfHandler_AddImageToPage_InvalidImage(t *testing.T) {
 		ImagePath: "testdata/test_signature-invalid.png",
 	}
 
-	err = handler.AddImageToPage(document, params)
+	err = handler.AddImageToPage(&document, params)
 	require.Error(t, err)
 	require.Equal(t, "failure at the C/MuPDF add_image_to_page function: unknown image file format", err.Error())
 }
@@ -702,12 +702,12 @@ func TestPdfHandler_AddTextBoxToPage(t *testing.T) {
 
 			document, err := handler.OpenPDF(file)
 			require.NoError(t, err, "OpenPDF failed")
-			defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+			defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
-			err = handler.AddTextBoxToPage(document, tt.params)
+			err = handler.AddTextBoxToPage(&document, tt.params)
 			require.NoError(t, err, "failed to add text")
 
-			err = handler.SavePDF(document, tt.outputFile)
+			err = handler.SavePDF(&document, tt.outputFile)
 			require.NoError(t, err, "failed to save PDF")
 		})
 	}
@@ -727,7 +727,7 @@ func TestPdfHandler_AddTextBoxToPage_InvalidPage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenPDF: %v", err)
 	}
-	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 	params := TextParams{
 		Value: "Hello, World!",
@@ -742,7 +742,7 @@ func TestPdfHandler_AddTextBoxToPage_InvalidPage(t *testing.T) {
 		}{Family: "Courier", Size: 12},
 	}
 
-	err = handler.AddTextBoxToPage(document, params)
+	err = handler.AddTextBoxToPage(&document, params)
 	require.Error(t, err)
 	require.Equal(t, "failure at the AddTextBoxToPage function: failed to get page size: failure at the C/MuPDF get_page_size function: invalid page number: 2", err.Error())
 }
@@ -761,7 +761,7 @@ func TestPdfHandler_AddTextBoxToPage_InvalidTextLengh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenPDF: %v", err)
 	}
-	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 	params := TextParams{
 		Value: strings.Repeat("a", 301),
@@ -776,7 +776,7 @@ func TestPdfHandler_AddTextBoxToPage_InvalidTextLengh(t *testing.T) {
 		}{Family: "Courier", Size: 12},
 	}
 
-	err = handler.AddTextBoxToPage(document, params)
+	err = handler.AddTextBoxToPage(&document, params)
 	require.Error(t, err)
 	require.Equal(t, "failure at the C/MuPDF add_text_to_page function: Text exceeds maximum allowed size. Expected: 300, Actual: 301", err.Error())
 }
@@ -795,7 +795,7 @@ func TestPdfHandler_AddTextBoxToPage_InvalidFont(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenPDF: %v", err)
 	}
-	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 	params := TextParams{
 		Value: "Hello, World!",
@@ -810,7 +810,7 @@ func TestPdfHandler_AddTextBoxToPage_InvalidFont(t *testing.T) {
 		}{Family: "[not existing font]", Size: 12},
 	}
 
-	err = handler.AddTextBoxToPage(document, params)
+	err = handler.AddTextBoxToPage(&document, params)
 	require.Error(t, err)
 	require.Equal(t, "failure at PdfHandler AddTextBoxToPage function: failed to find font path for \"[not existing font]\"", err.Error())
 }
@@ -907,12 +907,12 @@ func TestPdfHandler_AddCheckboxToPage(t *testing.T) {
 
 			document, err := handler.OpenPDF(file)
 			require.NoError(t, err, "OpenPDF failed")
-			defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+			defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
-			err = handler.AddCheckboxToPage(document, tt.params)
+			err = handler.AddCheckboxToPage(&document, tt.params)
 			require.NoError(t, err, "failed to add checkbox")
 
-			err = handler.SavePDF(document, tt.outputFile)
+			err = handler.SavePDF(&document, tt.outputFile)
 			require.NoError(t, err, "failed to save PDF")
 		})
 	}
@@ -932,7 +932,7 @@ func TestPdfHandler_AddCheckboxToPage_InvalidPage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenPDF: %v", err)
 	}
-	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 	params := CheckboxParams{
 		Value: true,
@@ -947,7 +947,7 @@ func TestPdfHandler_AddCheckboxToPage_InvalidPage(t *testing.T) {
 		}{Width: 20, Height: 20},
 	}
 
-	err = handler.AddCheckboxToPage(document, params)
+	err = handler.AddCheckboxToPage(&document, params)
 	require.Error(t, err)
 	require.Equal(t, "failure at the AddCheckboxToPage function: failed to get page size: failure at the C/MuPDF get_page_size function: invalid page number: 4", err.Error())
 }
@@ -966,11 +966,11 @@ func TestPdfHandler_SavePDF_Valid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenPDF: %v", err)
 	}
-	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 	outputPath := "tmp/output.pdf"
 
-	err = handler.SavePDF(document, outputPath)
+	err = handler.SavePDF(&document, outputPath)
 	if err != nil {
 		t.Fatalf("failed to save PDF: %v", err)
 	}
@@ -1003,7 +1003,7 @@ func TestPdfHandler_MultipleOperations(t *testing.T) {
 							Size   float64
 						}{Family: "Courier", Size: 12},
 					}
-					return handler.AddTextBoxToPage(document, params)
+					return handler.AddTextBoxToPage(&document, params)
 				},
 				func(handler PdfHandler, document PdfDocument) error {
 					params := TextParams{
@@ -1018,7 +1018,7 @@ func TestPdfHandler_MultipleOperations(t *testing.T) {
 							Size   float64
 						}{Family: "Courier", Size: 14},
 					}
-					return handler.AddTextBoxToPage(document, params)
+					return handler.AddTextBoxToPage(&document, params)
 				},
 				func(handler PdfHandler, document PdfDocument) error {
 					params := ImageParams{
@@ -1033,7 +1033,7 @@ func TestPdfHandler_MultipleOperations(t *testing.T) {
 						}{Width: 0.163, Height: 0.063},
 						ImagePath: "testdata/test_signature.png",
 					}
-					return handler.AddImageToPage(document, params)
+					return handler.AddImageToPage(&document, params)
 				},
 				func(handler PdfHandler, document PdfDocument) error {
 					params := CheckboxParams{
@@ -1048,7 +1048,7 @@ func TestPdfHandler_MultipleOperations(t *testing.T) {
 							Height float64
 						}{Width: 0.0327, Height: 0.0253},
 					}
-					return handler.AddCheckboxToPage(document, params)
+					return handler.AddCheckboxToPage(&document, params)
 				},
 				func(handler PdfHandler, document PdfDocument) error {
 					params := CheckboxParams{
@@ -1063,7 +1063,7 @@ func TestPdfHandler_MultipleOperations(t *testing.T) {
 							Height float64
 						}{Width: 0.0327, Height: 0.0253},
 					}
-					return handler.AddCheckboxToPage(document, params)
+					return handler.AddCheckboxToPage(&document, params)
 				},
 			},
 		},
@@ -1082,14 +1082,14 @@ func TestPdfHandler_MultipleOperations(t *testing.T) {
 
 			document, err := handler.OpenPDF(file)
 			require.NoError(t, err, "OpenPDF failed")
-			defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+			defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 			for _, operation := range tt.operations {
 				err := operation(handler, document)
 				require.NoError(t, err, "Operation failed")
 			}
 
-			err = handler.SavePDF(document, tt.outputFile)
+			err = handler.SavePDF(&document, tt.outputFile)
 			require.NoError(t, err, "Failed to save PDF")
 		})
 	}
@@ -1122,7 +1122,7 @@ func TestPdfHandler_MultipleOperationsOnTextboxes(t *testing.T) {
 						}{Width: 0.1633986928, Height: 0.0151515152},
 						ImagePath: "testdata/test_blue_box.png",
 					}
-					return handler.AddImageToPage(document, params)
+					return handler.AddImageToPage(&document, params)
 				},
 				func(handler PdfHandler, document PdfDocument) error {
 					params := ImageParams{
@@ -1137,7 +1137,7 @@ func TestPdfHandler_MultipleOperationsOnTextboxes(t *testing.T) {
 						}{Width: 0.1633986928, Height: 0.0151515152},
 						ImagePath: "testdata/test_blue_box.png",
 					}
-					return handler.AddImageToPage(document, params)
+					return handler.AddImageToPage(&document, params)
 				},
 				func(handler PdfHandler, document PdfDocument) error {
 					params := ImageParams{
@@ -1152,7 +1152,7 @@ func TestPdfHandler_MultipleOperationsOnTextboxes(t *testing.T) {
 						}{Width: 0.1633986928, Height: 0.0151515152},
 						ImagePath: "testdata/test_blue_box.png",
 					}
-					return handler.AddImageToPage(document, params)
+					return handler.AddImageToPage(&document, params)
 				},
 				func(handler PdfHandler, document PdfDocument) error {
 					params := TextParams{
@@ -1171,7 +1171,7 @@ func TestPdfHandler_MultipleOperationsOnTextboxes(t *testing.T) {
 							Size   float64
 						}{Family: "Times New Roman", Size: 12},
 					}
-					return handler.AddTextBoxToPage(document, params)
+					return handler.AddTextBoxToPage(&document, params)
 				},
 				func(handler PdfHandler, document PdfDocument) error {
 					params := TextParams{
@@ -1190,7 +1190,7 @@ func TestPdfHandler_MultipleOperationsOnTextboxes(t *testing.T) {
 							Size   float64
 						}{Family: "Times New Roman", Size: 12},
 					}
-					return handler.AddTextBoxToPage(document, params)
+					return handler.AddTextBoxToPage(&document, params)
 				},
 				func(handler PdfHandler, document PdfDocument) error {
 					params := TextParams{
@@ -1209,7 +1209,7 @@ func TestPdfHandler_MultipleOperationsOnTextboxes(t *testing.T) {
 							Size   float64
 						}{Family: "Times New Roman", Size: 12},
 					}
-					return handler.AddTextBoxToPage(document, params)
+					return handler.AddTextBoxToPage(&document, params)
 				},
 			},
 		},
@@ -1228,14 +1228,14 @@ func TestPdfHandler_MultipleOperationsOnTextboxes(t *testing.T) {
 
 			document, err := handler.OpenPDF(file)
 			require.NoError(t, err, "OpenPDF failed")
-			defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+			defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 			for _, operation := range tt.operations {
 				err := operation(handler, document)
 				require.NoError(t, err, "Operation failed")
 			}
 
-			err = handler.SavePDF(document, tt.outputFile)
+			err = handler.SavePDF(&document, tt.outputFile)
 			require.NoError(t, err, "Failed to save PDF")
 		})
 	}
@@ -1255,7 +1255,7 @@ func TestPdfHandler_SaveToPNGOK(t *testing.T) {
 
 			document, err := handler.OpenPDF(file)
 			require.NoError(t, err)
-			defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+			defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 			buf := bytes.NewBuffer([]byte{})
 			err = handler.SaveToPNG(document, i, 0, 0, 0, buf)
@@ -1301,7 +1301,7 @@ func benchmarkPdfHandlerSaveToPNGRunner(page uint16, b *testing.B) {
 		err = handler.SaveToPNG(document, page, 0, 0, 0, output)
 		require.NoError(b, err)
 
-		err = handler.ClosePDF(document)
+		err = handler.ClosePDF(&document)
 		require.NoError(b, err)
 	}
 }
@@ -1318,7 +1318,7 @@ func TestPdfHandler_WrapPageContents(t *testing.T) {
 
 	document, err := handler.OpenPDF(file)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 	// Initially, no pages should be wrapped
 	require.False(t, document.wrappedPages[0])
@@ -1350,7 +1350,7 @@ func TestPdfHandler_WrapPageContents_InvalidPage(t *testing.T) {
 
 	document, err := handler.OpenPDF(file)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 	// Call wrapPageContents with invalid page number should return error
 	err = handler.wrapPageContents(context.Background(), &document, 2)
@@ -1370,7 +1370,7 @@ func TestPdfHandler_WrapPageContents_Integration(t *testing.T) {
 
 	document, err := handler.OpenPDF(file)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(t, handler.ClosePDF(&document)) }()
 
 	// Test that annotation functions automatically wrap page contents
 	require.False(t, document.wrappedPages[0])
@@ -1387,7 +1387,7 @@ func TestPdfHandler_WrapPageContents_Integration(t *testing.T) {
 			Size:   12,
 		},
 	}
-	err = handler.AddTextBoxToPage(document, textParams)
+	err = handler.AddTextBoxToPage(&document, textParams)
 	require.NoError(t, err)
 	require.True(t, document.wrappedPages[0])
 
@@ -1399,7 +1399,7 @@ func TestPdfHandler_WrapPageContents_Integration(t *testing.T) {
 		Size:      Size{Width: 0.2, Height: 0.2},
 		ImagePath: "testdata/test_signature.png",
 	}
-	err = handler.AddImageToPage(document, imageParams)
+	err = handler.AddImageToPage(&document, imageParams)
 	require.NoError(t, err)
 	require.True(t, document.wrappedPages[1]) // Should still be true
 
@@ -1411,7 +1411,7 @@ func TestPdfHandler_WrapPageContents_Integration(t *testing.T) {
 		Location: Location{X: 0.7, Y: 0.7},
 		Size:     Size{Width: 0.05, Height: 0.05},
 	}
-	err = handler.AddCheckboxToPage(document, checkboxParams)
+	err = handler.AddCheckboxToPage(&document, checkboxParams)
 	require.NoError(t, err)
 	require.True(t, document.wrappedPages[2])
 }
@@ -1426,7 +1426,7 @@ func BenchmarkPdfHandler_WrapPageContentsPerformance(b *testing.B) {
 
 	document, err := handler.OpenPDF(file)
 	require.NoError(b, err)
-	defer func() { require.NoError(b, handler.ClosePDF(document)) }()
+	defer func() { require.NoError(b, handler.ClosePDF(&document)) }()
 
 	// Add first annotation to trigger initial wrap_page_contents call
 	// This is outside the benchmark timing
@@ -1443,7 +1443,7 @@ func BenchmarkPdfHandler_WrapPageContentsPerformance(b *testing.B) {
 			Size:   12,
 		},
 	}
-	err = handler.AddTextBoxToPage(document, firstTextParams)
+	err = handler.AddTextBoxToPage(&document, firstTextParams)
 	require.NoError(b, err)
 
 	require.True(b, document.wrappedPages[0], "Page should be wrapped after first annotation")
@@ -1468,7 +1468,7 @@ func BenchmarkPdfHandler_WrapPageContentsPerformance(b *testing.B) {
 				Size:   10,
 			},
 		}
-		err = handler.AddTextBoxToPage(document, textParams)
+		err = handler.AddTextBoxToPage(&document, textParams)
 		require.NoError(b, err)
 	}
 }


### PR DESCRIPTION
Fixes unsafe usage where a struct containing `sync.RWMutex` (PdfDocument) was being passed by value.

Copying a struct with a mutex can lead to unexpected behavior or race conditions. The affected function now accepts a pointer instead.

Changes
- Updated ClosePDF to accept *PdfDocument
- Updated call sites to pass by reference
- Prevents copying of sync.RWMutex-containing struct