### PR TITLE
Fix PdfDocument Pointer Consistency and Cross-Platform Line Ending Issues

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,10 +13,11 @@ import (
 
 // normalizeLineEndings converts all line endings to \n
 func normalizeLineEndings(data []byte) []byte {
-	s := string(data)
-	s = strings.ReplaceAll(s, "\r\n", "\n") // Windows to Unix
-	s = strings.ReplaceAll(s, "\r", "\n")   // Old Mac to Unix
-	return []byte(s)
+	// Replace Windows line endings (\r\n) with Unix (\n)
+	data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	// Replace old Mac line endings (\r) with Unix (\n)
+	data = bytes.ReplaceAll(data, []byte("\r"), []byte("\n"))
+	return data
 }
 
 func TestSaveToHTMLOK(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -6,10 +6,19 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// normalizeLineEndings converts all line endings to \n
+func normalizeLineEndings(data []byte) []byte {
+	s := string(data)
+	s = strings.ReplaceAll(s, "\r\n", "\n") // Windows to Unix
+	s = strings.ReplaceAll(s, "\r", "\n")   // Old Mac to Unix
+	return []byte(s)
+}
 
 func TestSaveToHTMLOK(t *testing.T) {
 	for i := uint16(0); i < 13; i++ {
@@ -25,7 +34,10 @@ func TestSaveToHTMLOK(t *testing.T) {
 		require.NoError(t, err)
 		resultPage, err := io.ReadAll(buf)
 		require.NoError(t, err)
-		require.Equal(t, expectedPage, resultPage)
+
+		expectedNormalized := normalizeLineEndings(expectedPage)
+		resultNormalized := normalizeLineEndings(resultPage)
+		require.Equal(t, expectedNormalized, resultNormalized)
 	}
 }
 

--- a/pdf_handler.go
+++ b/pdf_handler.go
@@ -184,7 +184,7 @@ func (p *PdfHandler) OpenPDF(rawPayload io.Reader) (document *PdfDocument, err e
 
 	filename, err := savePayloadToTempFile(ctx, rawPayload)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	cFilename := C.CString(filename)
@@ -205,7 +205,7 @@ func (p *PdfHandler) OpenPDF(rawPayload io.Reader) (document *PdfDocument, err e
 		defer C.je_free(unsafe.Pointer(output.error))
 		span.SetTag("c_function_error", true)
 		err = fmt.Errorf("failure at the C/MuPDF open_pdf function: %s", C.GoString(output.error))
-		return
+		return nil, err
 	}
 
 	pdf := PdfDocument{
@@ -214,7 +214,7 @@ func (p *PdfHandler) OpenPDF(rawPayload io.Reader) (document *PdfDocument, err e
 		wrappedPages: make(map[int]bool),
 	}
 	document = &pdf
-	return
+	return document, nil
 }
 
 func (p *PdfHandler) ClosePDF(document *PdfDocument) (err error) {

--- a/pdf_handler.go
+++ b/pdf_handler.go
@@ -214,6 +214,7 @@ func (p *PdfHandler) OpenPDF(rawPayload io.Reader) (document *PdfDocument, err e
 		wrappedPages: make(map[int]bool),
 	}
 	document = &pdf
+	return
 }
 
 func (p *PdfHandler) ClosePDF(document *PdfDocument) (err error) {

--- a/pdf_handler.go
+++ b/pdf_handler.go
@@ -184,7 +184,7 @@ func (p *PdfHandler) OpenPDF(rawPayload io.Reader) (document *PdfDocument, err e
 
 	filename, err := savePayloadToTempFile(ctx, rawPayload)
 	if err != nil {
-		return nil, err
+		return
 	}
 
 	cFilename := C.CString(filename)
@@ -204,7 +204,8 @@ func (p *PdfHandler) OpenPDF(rawPayload io.Reader) (document *PdfDocument, err e
 	if output.error != nil {
 		defer C.je_free(unsafe.Pointer(output.error))
 		span.SetTag("c_function_error", true)
-		return nil, fmt.Errorf("failure at the C/MuPDF open_pdf function: %s", C.GoString(output.error))
+		err = fmt.Errorf("failure at the C/MuPDF open_pdf function: %s", C.GoString(output.error))
+		return
 	}
 
 	pdf := PdfDocument{
@@ -212,7 +213,7 @@ func (p *PdfHandler) OpenPDF(rawPayload io.Reader) (document *PdfDocument, err e
 		file:         filename,
 		wrappedPages: make(map[int]bool),
 	}
-	return &pdf, nil
+	document = &pdf
 }
 
 func (p *PdfHandler) ClosePDF(document *PdfDocument) (err error) {


### PR DESCRIPTION
## Summary
This PR addresses two key issues: standardizes PdfDocument pointer usage across the codebase and fixes cross-platform line ending compatibility in HTML comparison tests.

## Changes Made
- PdfDocument Pointer Consistency
  - Fixed `OpenPDF` return type: Changed from returning `PdfDocument` by value to `*PdfDocument` pointer
  - Updated `SaveToPNG` parameter: Changed from accepting `PdfDocument` by value to `*PdfDocument` pointer
  - Updated all test calls: Modified all test functions to consistently use pointer references when calling PDF handler methods
- Cross-Platform Line Ending Support
  - Added `normalizeLineEndings` function: Converts Windows (\r\n) and old Mac (\r) line endings to Unix (\n) format
  - Updated HTML comparison tests: Applied line ending normalization before comparing expected vs actual HTML content