### PR TITLE
PIGS-995: part of the lazyraster ecosystem handover to NSS.

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -35,4 +35,4 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.sn_x_pub }}
           SNYK_API: https://app.eu.snyk.io/api
-        run: ${{ matrix.cmd }} --org=wapadi
+        run: ${{ matrix.cmd }} --org=sign-aande


### PR DESCRIPTION
Transfer lazyraster ecosystem + urlsign ownership to NSS

Ticket: https://gonitro.atlassian.net/browse/PIGS-995