### PR TITLE
Raise add-text limit to 500 characters and count characters, not bytes CW-4310

### DIFF
--- a/pdf_handler.c
+++ b/pdf_handler.c
@@ -390,6 +390,21 @@ void append_text_as_cid_hex_string(fz_context *ctx, fz_buffer *buf, fz_font *fon
     fz_append_byte(ctx, buf, '>');  // End hex string
 }
 
+// Count UTF-8 characters (codepoints) rather than bytes, so the limit matches the
+// character limit enforced by the calling service regardless of the script used.
+size_t count_utf8_characters(const char *text) {
+    int c;
+    size_t count    = 0;
+    const char *s   = text;
+
+    while (*s) {
+        s += fz_chartorune(&c, s);
+        count++;
+    }
+
+    return count;
+}
+
 void page_add_text(fz_context *ctx, pdf_page *page, const char *text, fz_point position, fz_font *font, float font_size) {
     fz_buffer *stream           = NULL;
     pdf_obj *resources          = NULL;
@@ -397,19 +412,20 @@ void page_add_text(fz_context *ctx, pdf_page *page, const char *text, fz_point p
     pdf_obj *font_ref           = NULL;
     char resource_name[32]      = "";
     fz_matrix matrix            = fz_identity;
-    size_t max_length           = 300;
+    size_t max_length           = 500;
 
     fz_var(stream);
     fz_var(font_ref);
 
     fz_try(ctx) {
 
-        size_t text_length  = strlen(text);
+        size_t text_length  = count_utf8_characters(text);
         if (text_length > max_length) {
             fz_throw(ctx, FZ_ERROR_GENERIC, "Text exceeds maximum allowed size. Expected: %zu, Actual: %zu", max_length, text_length);
         }
 
-        stream = fz_new_buffer(ctx, text_length * 2 + 500);
+        // Each character is written as 4 hex digits by append_text_as_cid_hex_string.
+        stream = fz_new_buffer(ctx, text_length * 4 + 500);
 
         // Add font to Resources using CID font for full Unicode support
         resources   = get_or_create_resources_dict(ctx, page->obj);

--- a/pdf_handler_font_test.go
+++ b/pdf_handler_font_test.go
@@ -306,7 +306,7 @@ func TestPdfHandler_AddTextBoxToPage_InvalidTextLengh(t *testing.T) {
 	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
 
 	params := TextParams{
-		Value: strings.Repeat("a", 301),
+		Value: strings.Repeat("a", 501),
 		Page:  0,
 		Location: Location{
 			X: 0.0,
@@ -324,7 +324,46 @@ func TestPdfHandler_AddTextBoxToPage_InvalidTextLengh(t *testing.T) {
 
 	err = handler.AddTextBoxToPage(document, params)
 	require.Error(t, err)
-	require.Equal(t, "failure at the C/MuPDF add_text_to_page function: Text exceeds maximum allowed size. Expected: 300, Actual: 301", err.Error())
+	require.Equal(t, "failure at the C/MuPDF add_text_to_page function: Text exceeds maximum allowed size. Expected: 500, Actual: 501", err.Error())
+}
+
+// The limit counts characters, not bytes, so multi-byte text is allowed the same
+// number of characters as ASCII text.
+func TestPdfHandler_AddTextBoxToPage_MultiByteTextAtLimit(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	handler := PdfHandler{Logger: logger}
+
+	file, err := os.Open("testdata/pdf_handler_sample.pdf")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, file.Close()) }()
+
+	document, err := handler.OpenPDF(file)
+	if err != nil {
+		t.Fatalf("OpenPDF: %v", err)
+	}
+	defer func() { require.NoError(t, handler.ClosePDF(document)) }()
+
+	// 500 characters, 1500 bytes in UTF-8.
+	params := TextParams{
+		Value: strings.Repeat("漢", 500),
+		Page:  0,
+		Location: Location{
+			X: 0.0,
+			Y: 0.0,
+		},
+		Size: Size{
+			Width:  443,
+			Height: 12,
+		},
+		Font: struct {
+			Family string
+			Size   float64
+		}{Family: "Times New Roman", Size: 12},
+	}
+
+	require.NoError(t, handler.AddTextBoxToPage(document, params))
 }
 
 func TestPdfHandler_AddTextBoxToPage_InvalidFont(t *testing.T) {


### PR DESCRIPTION
## Summary

The service that feeds this field caps text at **500 characters**. `page_add_text` capped at 300 and measured with `strlen`, so the two limits disagreed on both the number and the unit.

- `max_length` 300 → 500.
- Measure with a new `count_utf8_characters()` helper instead of `strlen`. Since the switch to CID fonts (6157acf) this path accepts full Unicode, so counting bytes gave non-Latin scripts a fraction of the intended allowance — 500 bytes is only ~166 CJK characters.
- Fix the content stream's initial capacity: `append_text_as_cid_hex_string` emits 4 hex digits per character, not 2 bytes per byte, so the old `* 2 + 500` estimate always forced a realloc. The `fz_buffer` grows on demand either way, so this is a sizing hint only — no correctness or safety impact.

## Tests

- `TestPdfHandler_AddTextBoxToPage_InvalidTextLengh` updated to 501/500.
- New `TestPdfHandler_AddTextBoxToPage_MultiByteTextAtLimit` pushes 500 CJK characters (1500 bytes) through, locking in the character-vs-byte behaviour — this would fail under the old `strlen` check.

## Notes for reviewers

- The 500 is now duplicated between this repo and the calling service. If that cap changes upstream, this becomes the binding constraint silently. Worth considering passing the limit in rather than hardcoding it.
- Unrelated but adjacent: there is still no wrapping or clipping. `page_add_text` emits a single unbounded `Tj` and ignores `params.Size.Width`, so long text runs past the page edge. The higher limit makes that easier to hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)